### PR TITLE
Fixed iPadOS 15.7 broswer version zero

### DIFF
--- a/.obsidian/workspace
+++ b/.obsidian/workspace
@@ -140,8 +140,8 @@
   },
   "active": "d66067b008492083",
   "lastOpenFiles": [
-    "README.md",
     "CODE_OF_CONDUCT.md",
-    "CONTRIBUTING.md"
+    "CONTRIBUTING.md",
+    "README.md"
   ]
 }

--- a/Detection/Directory.Build.props
+++ b/Detection/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>5.7.2</VersionPrefix>
+        <VersionPrefix>5.7.3</VersionPrefix>
 
         <Title>Wangkanai Detection</Title>
         <Description>ASP.NET Core Detection service components for identifying details about client device, browser, engine, platform, and crawler.</Description>

--- a/Detection/src/Extensions/VersionExtensions.cs
+++ b/Detection/src/Extensions/VersionExtensions.cs
@@ -19,6 +19,9 @@ public static class VersionExtensions
         if (!version.Contains(".", StringComparison.Ordinal))
             version += ".0";
 
+        if (version.Contains(",", StringComparison.Ordinal))
+            version = version.Replace(",", ".");
+
         return Version.TryParse(version, out var parsedVersion)
                    ? parsedVersion
                    : new Version(0, 0);

--- a/Detection/tests/Services/BrowserServiceTest.cs
+++ b/Detection/tests/Services/BrowserServiceTest.cs
@@ -54,6 +54,7 @@ public class BrowserServiceTest
     [InlineData("13.0.3", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1")]
     [InlineData("9.0", "Mozilla/5.0 (iPad; CPU OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1")]
     [InlineData("15.6.2", "mozilla/5.0 (macintosh; intel mac os x 10_15_6) applewebkit/605.1.15 (khtml, like gecko) version/15.6,2 safari/605.1.15")]
+    [InlineData("15.6.2", "mozilla/5.0 (ipad; cpu os 15_7 like mac os x) applewebkit/605.1.15 (khtml, like gecko) version/15.6,2 mobile/15e148 safari/604.1")]
     public void Safari(string version, string agent)
     {
         var resolver = MockService.BrowserService(agent);

--- a/Detection/tests/Services/BrowserServiceTest.cs
+++ b/Detection/tests/Services/BrowserServiceTest.cs
@@ -53,6 +53,7 @@ public class BrowserServiceTest
     [InlineData("85.0", "Mozilla/5.0 (Macintosh; U; PPC Mac OS X; de-ch) AppleWebKit/85 (KHTML, like Gecko) Safari/85")]
     [InlineData("13.0.3", "Mozilla/5.0 (iPhone; CPU iPhone OS 13_2_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.3 Mobile/15E148 Safari/604.1")]
     [InlineData("9.0", "Mozilla/5.0 (iPad; CPU OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13F69 Safari/601.1")]
+    [InlineData("15.6.2", "mozilla/5.0 (macintosh; intel mac os x 10_15_6) applewebkit/605.1.15 (khtml, like gecko) version/15.6,2 safari/605.1.15")]
     public void Safari(string version, string agent)
     {
         var resolver = MockService.BrowserService(agent);


### PR DESCRIPTION
#567 iPadOS - Apple typo causes detection as version zero