### PR TITLE
Property copy reflection helper

### DIFF
--- a/System/src/Reflection/PropertyCopy.cs
+++ b/System/src/Reflection/PropertyCopy.cs
@@ -1,0 +1,67 @@
+﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+using System.Linq.Expressions;
+
+namespace Wangkanai.Reflection;
+
+public static class PropertyCopy<TTarget> where TTarget : class, new()
+{
+	public static TTarget CopyFrom<TSource>(TSource source)
+		where TSource : class
+		=> PropertyCopier<TSource>.Copy(source);
+
+	private static class PropertyCopier<TSource> where TSource : class
+	{
+		private static readonly Exception              intializationException;
+		private static readonly Func<TSource, TTarget> copier;
+
+		static PropertyCopier()
+		{
+			try
+			{
+				copier                 = BuildCopier();
+				intializationException = null;
+			}
+			catch (Exception ex)
+			{
+				copier                 = null;
+				intializationException = ex;
+			}
+		}
+
+		internal static TTarget Copy(TSource source)
+		{
+			if (intializationException != null)
+				throw intializationException;
+
+			source.ThrowIfNull();
+
+			return copier(source);
+		}
+
+		private static Func<TSource, TTarget> BuildCopier()
+		{
+			var sourceParameter = Expression.Parameter(typeof(TSource), "source");
+			var bindings        = new List<MemberBinding>();
+
+			foreach (var sourceProperty in typeof(TSource).GetProperties())
+			{
+				if (!sourceProperty.CanRead)
+					continue;
+
+				var targetProperty = typeof(TTarget).GetProperty(sourceProperty.Name);
+
+				if (targetProperty is null)
+					throw new ArgumentException($"Property {sourceProperty.Name} is not found in {typeof(TTarget).FullName}");
+				if (!targetProperty.CanWrite)
+					throw new ArgumentException($"Property {sourceProperty.Name} is not writable in {typeof(TTarget).FullName}");
+				if (!targetProperty.PropertyType.IsAssignableFrom(sourceProperty.PropertyType))
+					throw new ArgumentException($"Property {sourceProperty.Name} is not assignable type in {targetProperty.PropertyType.FullName}");
+				bindings.Add(Expression.Bind(targetProperty, Expression.Property(sourceParameter, sourceProperty)));
+			}
+
+			var initializer = Expression.MemberInit(Expression.New(typeof(TTarget)), bindings);
+			return Expression.Lambda<Func<TSource, TTarget>>(initializer, sourceParameter).Compile();
+		}
+	}
+}

--- a/System/tests/Reflection/PropertyCopyTests.cs
+++ b/System/tests/Reflection/PropertyCopyTests.cs
@@ -1,0 +1,143 @@
+﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+using Xunit;
+
+namespace Wangkanai.Reflection;
+
+public class PropertyCopyTests
+{
+	[Fact]
+	public void CopyToSameType()
+	{
+		var source = new Simple { Value = "test" };
+		var target = PropertyCopy<Simple>.CopyFrom(source);
+
+		Assert.Equal("test", target.Value);
+	}
+
+	[Fact]
+	public void CopyToSimilarType()
+	{
+		var source = new Simple { Value = "test" };
+		var target = PropertyCopy<Other>.CopyFrom(source);
+
+		Assert.Equal("test", target.Value);
+	}
+
+	[Fact]
+	public void CopyAnonymousType()
+	{
+		var target = PropertyCopy<Simple>.CopyFrom(new { Value = "anonymous" });
+
+		Assert.Equal("anonymous", target.Value);
+	}
+
+	[Fact]
+	public void CopyFromGenericType()
+	{
+		var source = new Generic<string> { Value = "generic" };
+		var target = PropertyCopy<Simple>.CopyFrom(source);
+
+		Assert.Equal("generic", target.Value);
+	}
+
+	[Fact]
+	public void CopyToGenericType()
+	{
+		var source = new Simple { Value = "generic" };
+		var target = PropertyCopy<Generic<string>>.CopyFrom(source);
+
+		Assert.Equal("generic", target.Value);
+	}
+
+	[Fact]
+	public void MissingProperty()
+	{
+		Assert.Throws<ArgumentException>(() => PropertyCopy<Simple>.CopyFrom(new { Missing = "oh!" }));
+	}
+
+	[Fact]
+	public void ReadOnlyTargetPropertyThrows()
+	{
+		Assert.Throws<ArgumentException>(() => PropertyCopy<ReadOnly>.CopyFrom(new { Value = "oh!" }));
+	}
+
+	[Fact]
+	public void WriteOnlyTargetPropertyIgnored()
+	{
+		var source = new WriteOnly { Value = "copied", Write = "ignored" };
+		var target = PropertyCopy<Simple>.CopyFrom(source);
+
+		Assert.Equal("copied", target.Value);
+	}
+
+	[Fact]
+	public void IncorrectTypeThrows()
+	{
+		Assert.Throws<ArgumentException>(() => PropertyCopy<Simple>.CopyFrom(new { Value = 10 }));
+	}
+
+	[Fact]
+	public void MultipleProperties()
+	{
+		var target = PropertyCopy<Three>.CopyFrom(new { Third = true, Second = 20, First = "multiple" });
+
+		Assert.Equal("multiple", target.First);
+		Assert.Equal(20, target.Second);
+		Assert.True(target.Third);
+	}
+
+	[Fact]
+	public void DerivedTypeIsAccepted()
+	{
+		var source = new Generic<Derived>() { Value = new Derived() };
+		var target = PropertyCopy<Generic<Base>>.CopyFrom(source);
+		
+		Assert.Same(source.Value, target.Value);
+	}
+
+	[Fact]
+	public void BaseTypeIsRejected()
+	{
+		var source = new Generic<Base> { Value = new Base() };
+		Assert.Throws<ArgumentException>(() => PropertyCopy<Generic<Derived>>.CopyFrom(source));
+	}
+
+	class Base { }
+
+	class Derived : Base { }
+
+	class Simple
+	{
+		public string Value { get; set; }
+	}
+
+	class Other
+	{
+		public string Value { get; set; }
+	}
+
+	class ReadOnly
+	{
+		public string Value => "readonly";
+	}
+
+	class WriteOnly
+	{
+		public string writeField;
+		public string Write { set { writeField = value; } }
+		public string Value { get; set; }
+	}
+
+	class Generic<T>
+	{
+		public T Value { get; set; }
+	}
+
+	class Three
+	{
+		public string First  { get; set; }
+		public int    Second { get; set; }
+		public bool   Third  { get; set; }
+	}
+}


### PR DESCRIPTION
A generic class which copies to its target type from a source type specified in the Copy method. The types are specified separately to take advantage of type inference on generic method arguments.