### PR TITLE
#574 Remove netcoreapp3.1 from Detection

### DIFF
--- a/Analytics/Directory.Build.props
+++ b/Analytics/Directory.Build.props
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props"/>
     
     <PropertyGroup>
-        <VersionPrefix>0.11.4</VersionPrefix>
+        <VersionPrefix>0.12.0</VersionPrefix>
 
         <Title>Wangkanai Analytics</Title>
         <Description>Wangkanai Analytics is a .NET Core library extension that tracks and generates details statistics about visitors to your website. The core feature is to track website activity such as session duration, pages per session, bounce rate and etc. of individuals using the site, along with the information on the source of the traffic..</Description>

--- a/Analytics/src/Wangkanai.Analytics.csproj
+++ b/Analytics/src/Wangkanai.Analytics.csproj
@@ -1,15 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <Nullable>enable</Nullable>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <ImplicitUsings>true</ImplicitUsings>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj"/>
+    </ItemGroup>
 </Project>

--- a/Detection/Directory.Build.props
+++ b/Detection/Directory.Build.props
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props"/>
     
     <PropertyGroup>
-        <VersionPrefix>6.11.4</VersionPrefix>
+        <VersionPrefix>7.0.0</VersionPrefix>
 
         <Title>Wangkanai Detection</Title>
         <Description>ASP.NET Core Detection service components for identifying details about client device, browser, engine, platform, and crawler.</Description>

--- a/Detection/src/Wangkanai.Detection.csproj
+++ b/Detection/src/Wangkanai.Detection.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>8602,8603,8604</NoWarn>

--- a/Detection/src/Wangkanai.Detection.csproj
+++ b/Detection/src/Wangkanai.Detection.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
-    <LangVersion>preview</LangVersion>
-    <Nullable>enable</Nullable>
-    <NoWarn>8602,8603,8604</NoWarn>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+        <LangVersion>preview</LangVersion>
+        <Nullable>enable</Nullable>
+        <NoWarn>8602,8603,8604</NoWarn>
+    </PropertyGroup>
 
-  <ItemGroup>
-    <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
+    <ItemGroup>
+        <FrameworkReference Include="Microsoft.AspNetCore.App"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj" />
-    <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj"/>
+        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj"/>
+    </ItemGroup>
 
 </Project>
 

--- a/Responsive/Directory.Build.props
+++ b/Responsive/Directory.Build.props
@@ -2,7 +2,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props"/>
     
     <PropertyGroup>
-        <VersionPrefix>4.10.4</VersionPrefix>
+        <VersionPrefix>5.0.0</VersionPrefix>
 
         <Title>Wangkanai Responsive</Title>
         <PackageTags>aspnetcore;responsive;</PackageTags>

--- a/Responsive/src/Wangkanai.Responsive.csproj
+++ b/Responsive/src/Wangkanai.Responsive.csproj
@@ -1,22 +1,22 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;</TargetFrameworks>
-    <LangVersion>11</LangVersion>
-    <Nullable>enable</Nullable>
-    <NoWarn>8602,8632</NoWarn>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0;</TargetFrameworks>
+        <LangVersion>11</LangVersion>
+        <Nullable>enable</Nullable>
+        <NoWarn>8602,8632</NoWarn>
+    </PropertyGroup>
   
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0"/>
+    </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
-  </ItemGroup>
+    <ItemGroup Condition=" '$(TargetFramework)' == 'net7.0' ">
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0"/>
+    </ItemGroup>
 
-  <ItemGroup>
-    <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj" />
-  </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj"/>
+    </ItemGroup>
 
 </Project>

--- a/Responsive/src/Wangkanai.Responsive.csproj
+++ b/Responsive/src/Wangkanai.Responsive.csproj
@@ -1,15 +1,11 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;</TargetFrameworks>
     <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <NoWarn>8602,8632</NoWarn>
   </PropertyGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.0" />
-  </ItemGroup>
   
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />


### PR DESCRIPTION
As of December 13, 2022 Microsoft have end support for the .NET Core 3.1 We will follow this for us to enable to platform features.

https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core