### PR TITLE
[Federation] Exclusion hosts/ from source coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -13,13 +13,13 @@ sonar.sources=.
 sonar.exclusions=**/node_modules/**/*, **/lib/**/*, **/BenchmarkDotNet.Artifacts/**/*, **/benchmark/**/*, **/tests/**/*, **/demo/**/*, **/samples/**/*
 
 # Path to tests
-#sonar.tests=
+sonar.tests=.
+sonar.test.inclusions=**/tests/**/*
 #sonar.test.exclusions=
-#sonar.test.inclusions=
 
 # Source Coverage
 sonar.cs.dotcover.reportsPaths=dotCover.Output.html
-sonar.coverage.exclusions=**/tests/**/*, **/demo/**/*, **/samples/**/*, **/benchmark/**/*
+sonar.coverage.exclusions=**/tests/**/*, **/demo/**/*, **/samples/**/*, **/hosts/**/*, **/benchmark/**/*
 
 # Source encoding
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
We don't need code source coverage of the federation hosts test bed, its work similar to samples and demo.