### PR TITLE
[Webmaster] Regex require timeout to limit the execution time

### DIFF
--- a/Webmaster/src/Constants.cs
+++ b/Webmaster/src/Constants.cs
@@ -1,0 +1,8 @@
+﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai;
+
+internal static class Constants
+{
+	public static readonly TimeSpan RegexTimeout = TimeSpan.FromMilliseconds(100);
+}

--- a/Webmaster/src/Routing/LanguageRouteContraint.cs
+++ b/Webmaster/src/Routing/LanguageRouteContraint.cs
@@ -8,28 +8,28 @@ namespace Wangkanai.Webmaster.Routing;
 
 public sealed class EnglishLanguageRouteConstraint : RegexRouteConstraint
 {
-    public EnglishLanguageRouteConstraint() : base(new Regex("^[a-zA-Z]*$"))
-    {
-    }
+    public EnglishLanguageRouteConstraint() : base(new Regex("^[a-zA-Z]*$", RegexOptions.Compiled, Constants.RegexTimeout))
+	{
+	}
 }
 
 public sealed class ThaiLanguageRouteConstraint : RegexRouteConstraint
 {
-    public ThaiLanguageRouteConstraint() : base(new Regex(@"^\p{IsThai}*$"))
+    public ThaiLanguageRouteConstraint() : base(new Regex(@"^\p{IsThai}*$", RegexOptions.Compiled, Constants.RegexTimeout))
     {
     }
 }
 
 public sealed class LaoLanguageRouteConstraint : RegexRouteConstraint
 {
-    public LaoLanguageRouteConstraint() : base(new Regex(@"^\p{IsLao}*$"))
+    public LaoLanguageRouteConstraint() : base(new Regex(@"^\p{IsLao}*$", RegexOptions.Compiled, Constants.RegexTimeout))
     {
     }
 }
 
 public sealed class MyanmarLanguageRouteConstraint : RegexRouteConstraint
 {
-    public MyanmarLanguageRouteConstraint() : base(new Regex("^[U+1000–U+109F]*$"))
+    public MyanmarLanguageRouteConstraint() : base(new Regex("^[U+1000–U+109F]*$", RegexOptions.Compiled, Constants.RegexTimeout))
     {
     }
 }


### PR DESCRIPTION
Not specifying a timeout for regular expressions can lead to a Denial-of-Service attack. Pass a timeout when using System.Text.RegularExpressions to process untrusted input because a malicious user might craft a value for which the evaluation lasts excessively long.