### PR TITLE
Unit Test dependency are now set globally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,14 +20,24 @@
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     </PropertyGroup>
 
+    <!-- GitHub Source Link -->
+    <ItemGroup>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    </ItemGroup>
+    
+    <ItemGroup Condition="$(MSBuildProjectName.Contains('Test'))">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+        <PackageReference Include="Moq" Version="4.18.4" />
+        <PackageReference Include="xunit" Version="2.4.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" PrivateAssets="all" />
+        <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
+        <PackageReference Include="coverlet.msbuild" Version="6.0.0" PrivateAssets="all" />
+    </ItemGroup>
+    
     <!-- SonarScanner for MSBuild -->
     <PropertyGroup Condition="$(MSBuildProjectName.Contains('Benchmark'))">
         <SonarQubeExclude>true</SonarQubeExclude>
     </PropertyGroup>
-
-    <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    </ItemGroup>
 
     <!-- Source code settings -->
     <PropertyGroup>


### PR DESCRIPTION
This is ensure that all the test projects have the nuget package dependency version.