### PR TITLE
[System] All 'ThrowIfNull' method overloads should be adjacent.

### DIFF
--- a/System/src/Check.cs
+++ b/System/src/Check.cs
@@ -324,11 +324,7 @@ public static class Check
 
 	public static bool FalseIfNull<T>(this T? value)
 		=> !value.TrueIfNull();
-
-	[Obsolete(ObsoleteResources.Duplicated)]
-	public static T ReturnIfNotNull<T>(this T? value)
-		=> value ?? value!.ThrowIfNull<T>();
-
+	
 	#endregion
 
 #if NET7_0_OR_GREATER

--- a/System/src/Check.cs
+++ b/System/src/Check.cs
@@ -16,9 +16,7 @@ public static class Check
 	#region Throw
 
 	// Throw if value is null (all possible types)
-
-	#region ThrowIfNullStandard
-
+	
 	public static bool? ThrowIfNull(this bool? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
@@ -30,7 +28,6 @@ public static class Check
 
 	public static ushort? ThrowIfNull(this ushort? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
-
 
 	public static short? ThrowIfNull(this short? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
@@ -70,10 +67,6 @@ public static class Check
 
 	public static string ThrowIfNull(this string? value, string message)
 		=> ThrowIfNull<ArgumentNullException>(value, message);
-
-	#endregion
-
-	#region ThrowIfNullGeneric
 
 	public static bool? ThrowIfNull<T>(this bool? value)
 		where T : Exception
@@ -184,8 +177,7 @@ public static class Check
 
 	public static string ThrowIfNullOrWhitespace(this string? value)
 		=> ThrowIfNullOrWhitespace<ArgumentNullException>(value);
-
-
+	
 	public static string ThrowIfNullOrWhitespace(this string? value, string message)
 		=> ThrowIfNullOrWhitespace<ArgumentNullException>(value, message);
 
@@ -209,16 +201,13 @@ public static class Check
 		where T : Exception
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
-
 	public static object ThrowIfNull<T>(this object? value, string message)
 		where T : Exception
 		=> value ?? throw CreateExceptionInstance<T>(message);
 
-
 	public static T ThrowIfNull<T>(this T value)
 		=> value ?? throw CreateExceptionInstance<ArgumentNullException>(nameof(value));
-
-
+	
 	public static T ThrowIfNull<T>(this T value, string message)
 		=> value ?? throw CreateExceptionInstance<ArgumentNullException>(message);
 
@@ -264,12 +253,10 @@ public static class Check
 	public static bool ThrowIfMoreThan(this int value, int expected, [InvokerParameterName] string parameterName)
 		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, parameterName);
 
-
 	public static bool ThrowIfMoreThan<T>(this int value, int expected)
 		where T : ArgumentException
 		=> value.ThrowIfMoreThan<T>(expected, nameof(value));
-
-
+	
 	public static bool ThrowIfMoreThan<T>(this int value, int expected, [InvokerParameterName] string parameterName)
 		where T : ArgumentException
 		=> value > expected
@@ -317,23 +304,18 @@ public static class Check
 	public static bool ThrowIfZero(this int value)
 		=> value.ThrowIfZero<ArgumentZeroException>(nameof(value));
 
-
 	public static bool ThrowIfZero(this int value, [InvokerParameterName] string parameterName)
 		=> value.ThrowIfZero<ArgumentZeroException>(parameterName);
-
 
 	public static bool ThrowIfZero<T>(this int value)
 		where T : ArgumentException
 		=> value.ThrowIfZero<T>(nameof(value));
-
 
 	public static bool ThrowIfZero<T>(this int value, [InvokerParameterName] string parameterName)
 		where T : ArgumentException
 		=> value == 0
 			   ? throw CreateExceptionInstance<T>(parameterName)
 			   : true;
-
-	#endregion
 
 	#region IfNull
 

--- a/System/src/Extensions/StringExtensions.cs
+++ b/System/src/Extensions/StringExtensions.cs
@@ -12,13 +12,13 @@ public static class StringExtensions
 	public static bool IsNotNullOrEmpty(this string value)
 		=> !string.IsNullOrEmpty(value);
 
-	[ContractAnnotation("null => true")]
 	[DebuggerStepThrough]
+	[ContractAnnotation("null => true")]
 	public static bool IsNullOrEmpty(this string input)
 		=> string.IsNullOrEmpty(input);
 
-	[ContractAnnotation("null => true")]
 	[DebuggerStepThrough]
+	[ContractAnnotation("null => true")]
 	public static bool IsNullOrWhiteSpace(this string input)
 		=> string.IsNullOrWhiteSpace(input);
 

--- a/System/tests/CheckTests.cs
+++ b/System/tests/CheckTests.cs
@@ -355,10 +355,10 @@ public class CheckTests
 
 	#endregion
 
-	#region TrueIfNull
+	#region BooleanIfNull
 
 	[Fact]
-	public void IfNullThenReturnTrue()
+	public void CheckTrueIfNullThenReturnTrue()
 	{
 		byte?    _byte    = null;
 		short?   _short   = null;
@@ -382,7 +382,7 @@ public class CheckTests
 	}
 
 	[Fact]
-	public void TrueIfNullReturnFalse()
+	public void CheckTrueIfExistReturnFalse()
 	{
 		byte?    _byte    = 0;
 		short?   _short   = 0;
@@ -403,6 +403,54 @@ public class CheckTests
 		Assert.False(_decimal.TrueIfNull());
 		Assert.False(_char.TrueIfNull());
 		Assert.False(_string.TrueIfNull());
+	}
+	
+	[Fact]
+	public void CheckFalseIfNullThenReturnFalse()
+	{
+		byte?    _byte    = null;
+		short?   _short   = null;
+		int?     _int     = null;
+		long?    _long    = null;
+		float?   _float   = null;
+		double?  _double  = null;
+		decimal? _decimal = null;
+		char?    _char    = null;
+		string?  _string  = null;
+
+		Assert.False(_byte.FalseIfNull());
+		Assert.False(_short.FalseIfNull());
+		Assert.False(_int.FalseIfNull());
+		Assert.False(_long.FalseIfNull());
+		Assert.False(_float.FalseIfNull());
+		Assert.False(_double.FalseIfNull());
+		Assert.False(_decimal.FalseIfNull());
+		Assert.False(_char.FalseIfNull());
+		Assert.False(_string.FalseIfNull());
+	}
+
+	[Fact]
+	public void CheckFalseIfExistReturnFalse()
+	{
+		byte?    _byte    = 0;
+		short?   _short   = 0;
+		int?     _int     = 0;
+		long?    _long    = 0;
+		float?   _float   = 0;
+		double?  _double  = 0.0;
+		decimal? _decimal = 0;
+		char?    _char    = 'a';
+		string?  _string  = "xyz";
+
+		Assert.True(_byte.FalseIfNull());
+		Assert.True(_short.FalseIfNull());
+		Assert.True(_int.FalseIfNull());
+		Assert.True(_long.FalseIfNull());
+		Assert.True(_float.FalseIfNull());
+		Assert.True(_double.FalseIfNull());
+		Assert.True(_decimal.FalseIfNull());
+		Assert.True(_char.FalseIfNull());
+		Assert.True(_string.FalseIfNull());
 	}
 
 	#endregion


### PR DESCRIPTION
For clarity, all overloads of the same method should be grouped together. That lets both users and maintainers quickly understand all the current available options.