### PR TITLE
[System] Check for null add empty only condition

### DIFF
--- a/System/src/Check.cs
+++ b/System/src/Check.cs
@@ -15,155 +15,121 @@ public static class Check
 	#region Throw
 
 	// Throw if value is null (all possible types)
-	[DebuggerStepThrough]
 	public static bool? ThrowIfNull(this bool? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static sbyte? ThrowIfNull(this sbyte? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static byte? ThrowIfNull(this byte? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static ushort? ThrowIfNull(this ushort? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static short? ThrowIfNull(this short? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static int? ThrowIfNull(this int? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static uint? ThrowIfNull(this uint? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static nint? ThrowIfNull(this nint? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static nuint? ThrowIfNull(this nuint? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static long? ThrowIfNull(this long? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static ulong? ThrowIfNull(this ulong? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static float? ThrowIfNull(this float? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static decimal? ThrowIfNull(this decimal? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static double? ThrowIfNull(this double? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static char? ThrowIfNull(this char? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNull(this string? value)
 		=> ThrowIfNull<ArgumentNullException>(value);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNull(this string? value, string message)
 		=> ThrowIfNull<ArgumentNullException>(value, message);
 
-	[DebuggerStepThrough]
 	public static bool? ThrowIfNull<T>(this bool? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static sbyte? ThrowIfNull<T>(this sbyte? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static byte? ThrowIfNull<T>(this byte? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static short? ThrowIfNull<T>(this short? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static ushort? ThrowIfNull<T>(this ushort? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static int? ThrowIfNull<T>(this int? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static uint? ThrowIfNull<T>(this uint? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static nint? ThrowIfNull<T>(this nint? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static nuint? ThrowIfNull<T>(this nuint? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static long? ThrowIfNull<T>(this long? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static ulong? ThrowIfNull<T>(this ulong? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static float? ThrowIfNull<T>(this float? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static double? ThrowIfNull<T>(this double? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static decimal? ThrowIfNull<T>(this decimal? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static char? ThrowIfNull<T>(this char? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNull<T>(this string? value)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNull<T>(this string? value, string message)
 		where T : ArgumentException
 		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value), message);
@@ -171,19 +137,15 @@ public static class Check
 	#endregion
 
 	// Throw is value string is null or empty
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrEmpty(this string? value)
 		=> value.ThrowIfNullOrEmpty<ArgumentNullOrEmptyException>();
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrEmpty(this string? value, string message)
 		=> value.ThrowIfNullOrEmpty<ArgumentNullOrEmptyException>(message);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrEmpty(this string? value, string message, string paramName)
 		=> value.ThrowIfNullOrEmpty<ArgumentNullOrEmptyException>(message, paramName);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrEmpty<T>(this string? value)
 		where T : ArgumentException
 	{
@@ -192,7 +154,6 @@ public static class Check
 		return value!;
 	}
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrEmpty<T>(this string? value, string message)
 		where T : ArgumentException
 	{
@@ -201,7 +162,6 @@ public static class Check
 		return value!;
 	}
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrEmpty<T>(this string? value, string message, string paramName)
 		where T : ArgumentException
 	{
@@ -212,33 +172,27 @@ public static class Check
 
 	// Throw if value string is empty
 
-	[DebuggerStepThrough]
 	public static string ThrowIfEmpty(this string? value)
 		=> ThrowIfEmpty<ArgumentEmptyException>(value);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfEmpty(this string? value, string message)
 		=> ThrowIfEmpty<ArgumentEmptyException>(value, message);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfEmpty(this string? value, string message, string paramName)
 		=> ThrowIfEmpty<ArgumentEmptyException>(value, message, paramName);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value)
 		where T : ArgumentException
 		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw CreateArgumentExceptionInstance<T>(nameof(value))
 			   : value!;
 
-	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value, string message)
 		where T : ArgumentException
 		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw CreateArgumentExceptionInstance<T>(nameof(value), message)
 			   : value!;
 
-	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value, string message, string paramName)
 		where T : ArgumentException
 		=> value.ThrowIfNull<T>().IsEmpty()
@@ -246,25 +200,21 @@ public static class Check
 			   : value!;
 
 	// Throw if value string is null or whitespace
-	[DebuggerStepThrough]
+	
 	public static string ThrowIfNullOrWhitespace(this string? value)
 		=> ThrowIfNullOrWhitespace<ArgumentNullOrWhitespaceException>(value);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrWhitespace(this string? value, string message)
 		=> ThrowIfNullOrWhitespace<ArgumentNullOrWhitespaceException>(value, message);
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrWhitespace<T>(this string? value)
 		where T : ArgumentException
 		=> value.ThrowIfNullOrWhitespace<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrWhitespace<T>(this string? value, string message)
 		where T : ArgumentException
 		=> value.ThrowIfNullOrWhitespace<T>(message, nameof(value));
 
-	[DebuggerStepThrough]
 	public static string ThrowIfNullOrWhitespace<T>(this string? value, string message, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value.IsNullOrWhiteSpace()
@@ -272,36 +222,30 @@ public static class Check
 			   : value!;
 
 	// Throw if value object is null
-	[DebuggerStepThrough]
+	
 	public static object ThrowIfNull<T>(this object? value)
 		where T : Exception
 		=> value ?? throw CreateGenericExceptionInstance<T>();
 
-	[DebuggerStepThrough]
 	public static object ThrowIfNull<T>(this object? value, string message)
 		where T : Exception
 		=> value ?? throw CreateGenericExceptionInstance<T>(message);
 
-	[DebuggerStepThrough]
 	public static T ThrowIfNull<T>(this T value)
 		=> value ?? throw CreateArgumentExceptionInstance<ArgumentNullException>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static T ThrowIfNull<T>(this T value, string message)
 		=> value ?? throw CreateArgumentExceptionInstance<ArgumentNullException>(message);
 
 
 	// Throw if value is not equal to expected
-	[DebuggerStepThrough]
 	public static bool ThrowIfEqual(this int value, int expected)
 		=> value.ThrowIfEqual<ArgumentEqualException>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfEqual<T>(this int value, int expected)
 		where T : ArgumentException
 		=> value.ThrowIfEqual<T>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfEqual<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value == expected
@@ -309,16 +253,14 @@ public static class Check
 			   : false;
 
 	// Throw if value is not equal to expected
-	[DebuggerStepThrough]
+	
 	public static bool ThrowIfNotEqual(this int value, int expected)
 		=> value.ThrowIfNotEqual<ArgumentNotEqualException>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfNotEqual<T>(this int value, int expected)
 		where T : ArgumentException
 		=> value.ThrowIfNotEqual<T>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfNotEqual<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value != expected
@@ -326,20 +268,17 @@ public static class Check
 			   : true;
 
 	// Throw if value is less than expected
-	[DebuggerStepThrough]
+	
 	public static bool ThrowIfLessThan(this int value, int expected)
 		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfLessThan(this int value, int expected, [InvokerParameterName] string paramName)
 		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, paramName);
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfLessThan<T>(this int value, int expected)
 		where T : ArgumentException
 		=> value.ThrowIfLessThan<T>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfLessThan<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value < expected
@@ -347,20 +286,17 @@ public static class Check
 			   : true;
 
 	// Throw if value is more than expected
-	[DebuggerStepThrough]
+	
 	public static bool ThrowIfMoreThan(this int value, int expected)
 		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfMoreThan(this int value, int expected, [InvokerParameterName] string paramName)
 		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, paramName);
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfMoreThan<T>(this int value, int expected)
 		where T : ArgumentException
 		=> value.ThrowIfMoreThan<T>(expected, nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfMoreThan<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value > expected
@@ -368,20 +304,17 @@ public static class Check
 			   : true;
 
 	// Throw if value is negative
-	[DebuggerStepThrough]
+	
 	public static int ThrowIfNegative(this int value)
 		=> value.ThrowIfNegative<ArgumentNegativeException>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static int ThrowIfNegative(this int value, [InvokerParameterName] string paramName)
 		=> value.ThrowIfNegative<ArgumentNegativeException>(paramName);
 
-	[DebuggerStepThrough]
 	public static int ThrowIfNegative<T>(this int value)
 		where T : ArgumentException
 		=> value.ThrowIfNegative<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static int ThrowIfNegative<T>(this int value, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value < 0
@@ -389,20 +322,17 @@ public static class Check
 			   : value;
 
 	// Throw if value is positive
-	[DebuggerStepThrough]
+	
 	public static int ThrowIfPositive(this int value)
 		=> value.ThrowIfPositive<ArgumentPositiveException>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static int ThrowIfPositive(this int value, [InvokerParameterName] string paramName)
 		=> value.ThrowIfPositive<ArgumentPositiveException>(paramName);
 
-	[DebuggerStepThrough]
 	public static int ThrowIfPositive<T>(this int value)
 		where T : ArgumentException
 		=> value.ThrowIfPositive<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static int ThrowIfPositive<T>(this int value, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value < 0
@@ -410,20 +340,17 @@ public static class Check
 			   : value;
 
 	// Throw if value is zero
-	[DebuggerStepThrough]
+	
 	public static bool ThrowIfZero(this int value)
 		=> value.ThrowIfZero<ArgumentZeroException>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfZero(this int value, [InvokerParameterName] string paramName)
 		=> value.ThrowIfZero<ArgumentZeroException>(paramName);
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfZero<T>(this int value)
 		where T : ArgumentException
 		=> value.ThrowIfZero<T>(nameof(value));
 
-	[DebuggerStepThrough]
 	public static bool ThrowIfZero<T>(this int value, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value == 0
@@ -432,17 +359,14 @@ public static class Check
 
 	#region IfNull
 
-	[DebuggerStepThrough]
 	public static bool TrueIfNull<T>(this T? value)
 		=> value is null;
 
-	[DebuggerStepThrough]
 	public static bool FalseIfNull<T>(this T? value)
 		=> !value.TrueIfNull();
 
 	#endregion
 
-	[DebuggerStepThrough]
 	public static T ThrowIfOutOfRange<T>(this T index, [NonNegativeValue] T lower, [NonNegativeValue] T upper)
 		where T : IBinaryInteger<T>
 	{

--- a/System/src/Check.cs
+++ b/System/src/Check.cs
@@ -86,87 +86,87 @@ public static class Check
 	[DebuggerStepThrough]
 	public static bool? ThrowIfNull<T>(this bool? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static sbyte? ThrowIfNull<T>(this sbyte? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static byte? ThrowIfNull<T>(this byte? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static short? ThrowIfNull<T>(this short? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static ushort? ThrowIfNull<T>(this ushort? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static int? ThrowIfNull<T>(this int? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static uint? ThrowIfNull<T>(this uint? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static nint? ThrowIfNull<T>(this nint? value)
-		where T : Exception
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		where T : ArgumentException
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static nuint? ThrowIfNull<T>(this nuint? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static long? ThrowIfNull<T>(this long? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static ulong? ThrowIfNull<T>(this ulong? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static float? ThrowIfNull<T>(this float? value)
-		where T : Exception
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		where T : ArgumentException
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static double? ThrowIfNull<T>(this double? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static decimal? ThrowIfNull<T>(this decimal? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static char? ThrowIfNull<T>(this char? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static string ThrowIfNull<T>(this string? value)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static string ThrowIfNull<T>(this string? value, string message)
 		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(message);
+		=> value ?? throw CreateArgumentExceptionInstance<T>(nameof(value), message);
 
 	#endregion
 
@@ -188,7 +188,7 @@ public static class Check
 		where T : ArgumentException
 	{
 		if (value.IsNullOrEmpty())
-			throw CreateExceptionInstance<T>(nameof(value));
+			throw CreateArgumentExceptionInstance<T>(nameof(value));
 		return value!;
 	}
 
@@ -197,7 +197,7 @@ public static class Check
 		where T : ArgumentException
 	{
 		if (value.IsNullOrEmpty())
-			throw CreateExceptionInstance<T>(message);
+			throw CreateArgumentExceptionInstance<T>(nameof(value), message);
 		return value!;
 	}
 
@@ -206,43 +206,43 @@ public static class Check
 		where T : ArgumentException
 	{
 		if (value.IsNullOrEmpty())
-			throw CreateExceptionInstance<T>(message, paramName);
+			throw CreateArgumentExceptionInstance<T>(paramName, message);
 		return value!;
 	}
-	
+
 	// Throw if value string is empty
-	
+
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty(this string? value)
 		=> ThrowIfEmpty<ArgumentEmptyException>(value);
-	
+
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty(this string? value, string message)
 		=> ThrowIfEmpty<ArgumentEmptyException>(value, message);
-	
+
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty(this string? value, string message, string paramName)
 		=> ThrowIfEmpty<ArgumentEmptyException>(value, message, paramName);
-	
+
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value)
 		where T : ArgumentException
-		=> value.IsEmpty() 
-			   ? throw CreateExceptionInstance<T>(nameof(value)) 
+		=> value.IsEmpty()
+			   ? throw CreateArgumentExceptionInstance<T>(nameof(value))
 			   : value!;
 
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value, string message)
 		where T : ArgumentException
-		=> value.IsEmpty() 
-			   ? throw CreateExceptionInstance<T>(message) 
+		=> value.IsEmpty()
+			   ? throw CreateArgumentExceptionInstance<T>(nameof(value), message)
 			   : value!;
 
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value, string message, string paramName)
 		where T : ArgumentException
-		=> value.IsEmpty() 
-			   ? throw CreateExceptionInstance<T>(message, paramName) 
+		=> value.IsEmpty()
+			   ? throw CreateArgumentExceptionInstance<T>(paramName, message)
 			   : value!;
 
 	// Throw if value string is null or whitespace
@@ -265,30 +265,30 @@ public static class Check
 		=> value.ThrowIfNullOrWhitespace<T>(message, nameof(value));
 
 	[DebuggerStepThrough]
-	public static string ThrowIfNullOrWhitespace<T>(this string? value, string message, [InvokerParameterName] string parameterName)
+	public static string ThrowIfNullOrWhitespace<T>(this string? value, string message, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value.IsNullOrWhiteSpace()
-			   ? throw CreateExceptionInstance<T>(message, parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName, message)
 			   : value!;
 
 	// Throw if value object is null
 	[DebuggerStepThrough]
 	public static object ThrowIfNull<T>(this object? value)
-		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
+		where T : Exception
+		=> value ?? throw CreateGenericExceptionInstance<T>();
 
 	[DebuggerStepThrough]
 	public static object ThrowIfNull<T>(this object? value, string message)
-		where T : ArgumentException
-		=> value ?? throw CreateExceptionInstance<T>(message);
+		where T : Exception
+		=> value ?? throw CreateGenericExceptionInstance<T>(message);
 
 	[DebuggerStepThrough]
 	public static T ThrowIfNull<T>(this T value)
-		=> value ?? throw CreateExceptionInstance<ArgumentNullException>(nameof(value));
+		=> value ?? throw CreateArgumentExceptionInstance<ArgumentNullException>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static T ThrowIfNull<T>(this T value, string message)
-		=> value ?? throw CreateExceptionInstance<ArgumentNullException>(message);
+		=> value ?? throw CreateArgumentExceptionInstance<ArgumentNullException>(message);
 
 
 	// Throw if value is not equal to expected
@@ -302,12 +302,12 @@ public static class Check
 		=> value.ThrowIfEqual<T>(expected, nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfEqual<T>(this int value, int expected, [InvokerParameterName] string parameterName)
+	public static bool ThrowIfEqual<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value == expected
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : false;
-	
+
 	// Throw if value is not equal to expected
 	[DebuggerStepThrough]
 	public static bool ThrowIfNotEqual(this int value, int expected)
@@ -319,10 +319,10 @@ public static class Check
 		=> value.ThrowIfNotEqual<T>(expected, nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfNotEqual<T>(this int value, int expected, [InvokerParameterName] string parameterName)
+	public static bool ThrowIfNotEqual<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value != expected
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : true;
 
 	// Throw if value is less than expected
@@ -331,8 +331,8 @@ public static class Check
 		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfLessThan(this int value, int expected, [InvokerParameterName] string parameterName)
-		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, parameterName);
+	public static bool ThrowIfLessThan(this int value, int expected, [InvokerParameterName] string paramName)
+		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, paramName);
 
 	[DebuggerStepThrough]
 	public static bool ThrowIfLessThan<T>(this int value, int expected)
@@ -340,10 +340,10 @@ public static class Check
 		=> value.ThrowIfLessThan<T>(expected, nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfLessThan<T>(this int value, int expected, [InvokerParameterName] string parameterName)
+	public static bool ThrowIfLessThan<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value < expected
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : true;
 
 	// Throw if value is more than expected
@@ -352,8 +352,8 @@ public static class Check
 		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfMoreThan(this int value, int expected, [InvokerParameterName] string parameterName)
-		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, parameterName);
+	public static bool ThrowIfMoreThan(this int value, int expected, [InvokerParameterName] string paramName)
+		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, paramName);
 
 	[DebuggerStepThrough]
 	public static bool ThrowIfMoreThan<T>(this int value, int expected)
@@ -361,10 +361,10 @@ public static class Check
 		=> value.ThrowIfMoreThan<T>(expected, nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfMoreThan<T>(this int value, int expected, [InvokerParameterName] string parameterName)
+	public static bool ThrowIfMoreThan<T>(this int value, int expected, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value > expected
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : true;
 
 	// Throw if value is negative
@@ -373,8 +373,8 @@ public static class Check
 		=> value.ThrowIfNegative<ArgumentNegativeException>(nameof(value));
 
 	[DebuggerStepThrough]
-	public static int ThrowIfNegative(this int value, [InvokerParameterName] string parameterName)
-		=> value.ThrowIfNegative<ArgumentNegativeException>(parameterName);
+	public static int ThrowIfNegative(this int value, [InvokerParameterName] string paramName)
+		=> value.ThrowIfNegative<ArgumentNegativeException>(paramName);
 
 	[DebuggerStepThrough]
 	public static int ThrowIfNegative<T>(this int value)
@@ -382,10 +382,10 @@ public static class Check
 		=> value.ThrowIfNegative<T>(nameof(value));
 
 	[DebuggerStepThrough]
-	public static int ThrowIfNegative<T>(this int value, [InvokerParameterName] string parameterName)
+	public static int ThrowIfNegative<T>(this int value, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value < 0
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : value;
 
 	// Throw if value is positive
@@ -394,8 +394,8 @@ public static class Check
 		=> value.ThrowIfPositive<ArgumentPositiveException>(nameof(value));
 
 	[DebuggerStepThrough]
-	public static int ThrowIfPositive(this int value, [InvokerParameterName] string parameterName)
-		=> value.ThrowIfPositive<ArgumentPositiveException>(parameterName);
+	public static int ThrowIfPositive(this int value, [InvokerParameterName] string paramName)
+		=> value.ThrowIfPositive<ArgumentPositiveException>(paramName);
 
 	[DebuggerStepThrough]
 	public static int ThrowIfPositive<T>(this int value)
@@ -403,10 +403,10 @@ public static class Check
 		=> value.ThrowIfPositive<T>(nameof(value));
 
 	[DebuggerStepThrough]
-	public static int ThrowIfPositive<T>(this int value, [InvokerParameterName] string parameterName)
+	public static int ThrowIfPositive<T>(this int value, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value < 0
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : value;
 
 	// Throw if value is zero
@@ -415,8 +415,8 @@ public static class Check
 		=> value.ThrowIfZero<ArgumentZeroException>(nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfZero(this int value, [InvokerParameterName] string parameterName)
-		=> value.ThrowIfZero<ArgumentZeroException>(parameterName);
+	public static bool ThrowIfZero(this int value, [InvokerParameterName] string paramName)
+		=> value.ThrowIfZero<ArgumentZeroException>(paramName);
 
 	[DebuggerStepThrough]
 	public static bool ThrowIfZero<T>(this int value)
@@ -424,10 +424,10 @@ public static class Check
 		=> value.ThrowIfZero<T>(nameof(value));
 
 	[DebuggerStepThrough]
-	public static bool ThrowIfZero<T>(this int value, [InvokerParameterName] string parameterName)
+	public static bool ThrowIfZero<T>(this int value, [InvokerParameterName] string paramName)
 		where T : ArgumentException
 		=> value == 0
-			   ? throw CreateExceptionInstance<T>(parameterName)
+			   ? throw CreateArgumentExceptionInstance<T>(paramName)
 			   : true;
 
 	#region IfNull
@@ -454,13 +454,29 @@ public static class Check
 
 	#region Instance
 
-	private static T CreateExceptionInstance<T>(string name)
-		where T : ArgumentException
-		=> (Activator.CreateInstance(typeof(T), name) as T)!;
+	private static T CreateGenericExceptionInstance<T>()
+		where T : Exception
+		=> (Activator.CreateInstance(typeof(T)) as T)!;
 
-	private static T CreateExceptionInstance<T>(string name, string paramName)
+	private static T CreateGenericExceptionInstance<T>(string message)
+		where T : Exception
+		=> (Activator.CreateInstance(typeof(T), message) as T)!;
+
+	private static T CreateGenericExceptionInstance<T>(string message, Exception? innerException)
+		where T : Exception
+		=> (Activator.CreateInstance(typeof(T), message, innerException) as T)!;
+
+	private static T CreateArgumentExceptionInstance<T>(string paramName)
 		where T : ArgumentException
-		=> (Activator.CreateInstance(typeof(T), name, paramName) as T)!;
+		=> (Activator.CreateInstance(typeof(T), paramName) as T)!;
+
+	private static T CreateArgumentExceptionInstance<T>(string paramName, string message)
+		where T : ArgumentException
+		=> (Activator.CreateInstance(typeof(T), message, paramName) as T)!;
+
+	private static T CreateArgumentExceptionInstance<T>(string paramName, string message, Exception? innerException)
+		where T : ArgumentException
+		=> (Activator.CreateInstance(typeof(T), message, paramName, innerException) as T)!;
 
 	#endregion
 }

--- a/System/src/Check.cs
+++ b/System/src/Check.cs
@@ -227,21 +227,21 @@ public static class Check
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value)
 		where T : ArgumentException
-		=> value.IsEmpty()
+		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw CreateArgumentExceptionInstance<T>(nameof(value))
 			   : value!;
 
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value, string message)
 		where T : ArgumentException
-		=> value.IsEmpty()
+		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw CreateArgumentExceptionInstance<T>(nameof(value), message)
 			   : value!;
 
 	[DebuggerStepThrough]
 	public static string ThrowIfEmpty<T>(this string? value, string message, string paramName)
 		where T : ArgumentException
-		=> value.IsEmpty()
+		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw CreateArgumentExceptionInstance<T>(paramName, message)
 			   : value!;
 

--- a/System/src/Check.cs
+++ b/System/src/Check.cs
@@ -85,37 +85,37 @@ public static class Check
 
 	[DebuggerStepThrough]
 	public static bool? ThrowIfNull<T>(this bool? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static sbyte? ThrowIfNull<T>(this sbyte? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static byte? ThrowIfNull<T>(this byte? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static short? ThrowIfNull<T>(this short? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static ushort? ThrowIfNull<T>(this ushort? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static int? ThrowIfNull<T>(this int? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static uint? ThrowIfNull<T>(this uint? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
@@ -125,17 +125,17 @@ public static class Check
 
 	[DebuggerStepThrough]
 	public static nuint? ThrowIfNull<T>(this nuint? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static long? ThrowIfNull<T>(this long? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static ulong? ThrowIfNull<T>(this ulong? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
@@ -145,27 +145,27 @@ public static class Check
 
 	[DebuggerStepThrough]
 	public static double? ThrowIfNull<T>(this double? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static decimal? ThrowIfNull<T>(this decimal? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static char? ThrowIfNull<T>(this char? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static string ThrowIfNull<T>(this string? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static string ThrowIfNull<T>(this string? value, string message)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(message);
 
 	#endregion
@@ -209,6 +209,41 @@ public static class Check
 			throw CreateExceptionInstance<T>(message, paramName);
 		return value!;
 	}
+	
+	// Throw if value string is empty
+	
+	[DebuggerStepThrough]
+	public static string ThrowIfEmpty(this string? value)
+		=> ThrowIfEmpty<ArgumentEmptyException>(value);
+	
+	[DebuggerStepThrough]
+	public static string ThrowIfEmpty(this string? value, string message)
+		=> ThrowIfEmpty<ArgumentEmptyException>(value, message);
+	
+	[DebuggerStepThrough]
+	public static string ThrowIfEmpty(this string? value, string message, string paramName)
+		=> ThrowIfEmpty<ArgumentEmptyException>(value, message, paramName);
+	
+	[DebuggerStepThrough]
+	public static string ThrowIfEmpty<T>(this string? value)
+		where T : ArgumentException
+		=> value.IsEmpty() 
+			   ? throw CreateExceptionInstance<T>(nameof(value)) 
+			   : value!;
+
+	[DebuggerStepThrough]
+	public static string ThrowIfEmpty<T>(this string? value, string message)
+		where T : ArgumentException
+		=> value.IsEmpty() 
+			   ? throw CreateExceptionInstance<T>(message) 
+			   : value!;
+
+	[DebuggerStepThrough]
+	public static string ThrowIfEmpty<T>(this string? value, string message, string paramName)
+		where T : ArgumentException
+		=> value.IsEmpty() 
+			   ? throw CreateExceptionInstance<T>(message, paramName) 
+			   : value!;
 
 	// Throw if value string is null or whitespace
 	[DebuggerStepThrough]
@@ -239,12 +274,12 @@ public static class Check
 	// Throw if value object is null
 	[DebuggerStepThrough]
 	public static object ThrowIfNull<T>(this object? value)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(nameof(value));
 
 	[DebuggerStepThrough]
 	public static object ThrowIfNull<T>(this object? value, string message)
-		where T : Exception
+		where T : ArgumentException
 		=> value ?? throw CreateExceptionInstance<T>(message);
 
 	[DebuggerStepThrough]
@@ -420,7 +455,7 @@ public static class Check
 	#region Instance
 
 	private static T CreateExceptionInstance<T>(string name)
-		where T : Exception
+		where T : ArgumentException
 		=> (Activator.CreateInstance(typeof(T), name) as T)!;
 
 	private static T CreateExceptionInstance<T>(string name, string paramName)

--- a/System/src/Extensions/StringExtensions.cs
+++ b/System/src/Extensions/StringExtensions.cs
@@ -9,6 +9,10 @@ namespace Wangkanai.Extensions;
 public static class StringExtensions
 {
 	[DebuggerStepThrough]
+	public static bool IsEmpty(this string value)
+		=> value == string.Empty;
+	
+	[DebuggerStepThrough]
 	public static bool IsNullOrEmpty(this string value)
 		=> string.IsNullOrEmpty(value);
 
@@ -276,10 +280,10 @@ public static class StringExtensions
 	{
 		value.ThrowIfNull();
 		value.ThrowIfNullOrEmpty();
-		
+
 		Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-		var encoding = Encoding.GetEncoding("Cyrillic");
-		byte[] bytes = encoding.GetBytes(value);
+		var    encoding = Encoding.GetEncoding("Cyrillic");
+		byte[] bytes    = encoding.GetBytes(value);
 		return Encoding.ASCII.GetString(bytes);
 	}
 
@@ -299,7 +303,6 @@ public static class StringExtensions
 
 		return str;
 	}
-
 
 	[DebuggerStepThrough]
 	public static bool EqualsInvariant(this string str1, string str2)

--- a/System/tests/Checks/CheckStringTests.cs
+++ b/System/tests/Checks/CheckStringTests.cs
@@ -25,7 +25,16 @@ public class CheckStringTests
 	}
 
 	[Fact]
-	public void StringIsNullOrEmptyThrowNullException()
+	public void StringIsEmpty()
+	{
+		string? _null  = null;
+		string? _empty = string.Empty;
+		
+		Assert.Throws<ArgumentEmptyException>(() => _null.ThrowIfEmpty());
+	}
+
+	[Fact]
+	public void StringIsNullOrEmptyThrowNull()
 	{
 		string? _null  = null;
 		string? _empty = string.Empty;
@@ -40,7 +49,7 @@ public class CheckStringTests
 	}
 
 	[Fact]
-	public void StringIsNullOrEmptyThrowArgumentException()
+	public void StringIsNullOrEmptyThrowException()
 	{
 		string? _null  = null;
 		string? _empty = string.Empty;

--- a/System/tests/Checks/CheckStringTests.cs
+++ b/System/tests/Checks/CheckStringTests.cs
@@ -31,6 +31,42 @@ public class CheckStringTests
 		string? _empty = string.Empty;
 		
 		Assert.Throws<ArgumentEmptyException>(() => _null.ThrowIfEmpty());
+		Assert.Throws<ArgumentEmptyException>(() => _null.ThrowIfEmpty<ArgumentEmptyException>());
+		Assert.Throws<CustomNullException>(() => _null.ThrowIfEmpty<CustomNullException>());
+		
+		Assert.Throws<ArgumentEmptyException>(() => _empty.ThrowIfEmpty());
+		Assert.Throws<ArgumentEmptyException>(() => _empty.ThrowIfEmpty<ArgumentEmptyException>());
+		Assert.Throws<CustomNullException>(() => _empty.ThrowIfEmpty<CustomNullException>());
+	}
+	
+	[Fact]
+	public void StringIsEmptyThrowException()
+	{
+		string? _null  = null;
+		string? _empty = string.Empty;
+		
+		Assert.Throws<ArgumentException>(() => _null.ThrowIfEmpty<ArgumentException>());
+		Assert.Throws<ArgumentException>(() => _null.ThrowIfEmpty<ArgumentException>("Empty Exception"));
+		Assert.Throws<ArgumentException>(() => _null.ThrowIfEmpty<ArgumentException>("Empty Exception", nameof(_null)));
+		
+		Assert.Throws<ArgumentException>(() => _empty.ThrowIfEmpty<ArgumentException>());
+		Assert.Throws<ArgumentException>(() => _empty.ThrowIfEmpty<ArgumentException>("Empty Exception"));
+		Assert.Throws<ArgumentException>(() => _empty.ThrowIfEmpty<ArgumentException>("Empty Exception", nameof(_empty)));
+	}
+
+	[Fact]
+	public void StringIsNotEmptyReturnValue()
+	{
+		var abc = "abc";
+		
+		Assert.Equal(abc, abc.ThrowIfEmpty());
+		Assert.Equal(abc, abc.ThrowIfEmpty<ArgumentEmptyException>());
+		Assert.Equal(abc, abc.ThrowIfEmpty<ArgumentEmptyException>("Empty Exception"));
+		Assert.Equal(abc, abc.ThrowIfEmpty<ArgumentEmptyException>("Empty Exception", nameof(abc)));
+		
+		Assert.Equal(abc, abc.ThrowIfEmpty<CustomNullException>());
+		Assert.Equal(abc, abc.ThrowIfEmpty<CustomNullException>("Empty Exception"));
+		Assert.Equal(abc, abc.ThrowIfEmpty<CustomNullException>("Empty Exception", nameof(abc)));
 	}
 
 	[Fact]


### PR DESCRIPTION
The check for null is now getting more complicated with each new edge case during my investigative journey. I find that we should have checking just for empty string. Also adding to this, an ArgumentEmptyException to go along with the check.

Then come the point of the instance activator of creating exception instance when the condition is found to be throw.