### PR TITLE
[Federation] Non-nullable property 'Request' must contain a non-null

### DIFF
--- a/Federation/src/Federation/Responses/Models/AuthorizeResponse.cs
+++ b/Federation/src/Federation/Responses/Models/AuthorizeResponse.cs
@@ -11,15 +11,15 @@ public class AuthorizeResponse
 	public string RedirectUri => Request?.RedirectUri;
 	public string State       => Request?.State;
 	public string Scope       => Request?.ValidationResources?.RawScopeValues.SeparateToSpace();
+	public bool   IsError     => Error.IsExist();
 
+	public int    AccessTokenLifetime { get; set; }
 	public string IdentityToken       { get; set; }
 	public string AccessToken         { get; set; }
-	public int    AccessTokenLifetime { get; set; }
 	public string SessionState        { get; set; }
 
 	public string Code        { get; set; }
 	public string Issuer      { get; set; }
 	public string Error       { get; set; }
 	public string Description { get; set; }
-	public bool   IsError     => Error.IsExist();
 }

--- a/Federation/src/Federation/Responses/Models/AuthorizeResponse.cs
+++ b/Federation/src/Federation/Responses/Models/AuthorizeResponse.cs
@@ -6,7 +6,7 @@ namespace Wangkanai.Federation.Responses;
 
 public class AuthorizeResponse
 {
-	public ValidationAuthorizeRequest Request { get; set; }
+	public ValidationAuthorizeRequest? Request { get; set; }
 
 	public string RedirectUri => Request?.RedirectUri;
 	public string State       => Request?.State;


### PR DESCRIPTION
Non-nullable property 'Request' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.

https://sonarcloud.io/project/issues?open=AYiQOw-SGLfIxx_yfDfn&id=wangkanai_wangkanai