### PR TITLE
[Validation] Fixed unit tests build warnings]

### DIFF
--- a/Validation/tests/Models/BaseModel.cs
+++ b/Validation/tests/Models/BaseModel.cs
@@ -9,7 +9,7 @@ public class BaseModel
 	public static PropertyInfo GetProperty<T>(string name)
 		where T : BaseModel
 	{
-		return typeof(T).GetProperty(name);
+		return typeof(T).GetProperty(name)!;
 	}
 }
 
@@ -17,6 +17,6 @@ public class BaseModel<T>
 {
 	public static PropertyInfo GetProperty(string name)
 	{
-		return typeof(T).GetProperty(name);
+		return typeof(T).GetProperty(name)!;
 	}
 }

--- a/Validation/tests/Models/BaseModel.cs
+++ b/Validation/tests/Models/BaseModel.cs
@@ -8,15 +8,11 @@ public class BaseModel
 {
 	public static PropertyInfo GetProperty<T>(string name)
 		where T : BaseModel
-	{
-		return typeof(T).GetProperty(name)!;
-	}
+		=> typeof(T).GetProperty(name)!;
 }
 
 public class BaseModel<T>
 {
 	public static PropertyInfo GetProperty(string name)
-	{
-		return typeof(T).GetProperty(name)!;
-	}
+		=> typeof(T).GetProperty(name)!;
 }

--- a/Validation/tests/Models/DigitModel.cs
+++ b/Validation/tests/Models/DigitModel.cs
@@ -7,5 +7,5 @@ namespace Wangkanai.Validation.Models;
 public class DigitModel : BaseModel<DigitModel>, IPasswordModel
 {
 	[RequireDigit]
-	public string Password { get; set; }
+	public string Password { get; set; } = string.Empty;
 }

--- a/Validation/tests/Models/LowercaseModel.cs
+++ b/Validation/tests/Models/LowercaseModel.cs
@@ -7,5 +7,5 @@ namespace Wangkanai.Validation.Models;
 public class LowercaseModel : BaseModel<LowercaseModel>, IPasswordModel
 {
 	[RequireLowercase]
-	public string Password { get; set; }
+	public string Password { get; set; } = string.Empty;
 }

--- a/Validation/tests/Models/NonAlphanumericModel.cs
+++ b/Validation/tests/Models/NonAlphanumericModel.cs
@@ -8,5 +8,5 @@ public class NonAlphanumericModel : BaseModel<NonAlphanumericModel>, IPasswordMo
 {
 	[Required]
 	[RequireNonAlphanumeric]
-	public string Password { get; set; }
+	public string Password { get; set; } = string.Empty;
 }

--- a/Validation/tests/Models/UniqueModel.cs
+++ b/Validation/tests/Models/UniqueModel.cs
@@ -7,14 +7,14 @@ namespace Wangkanai.Validation.Models;
 public class UniqueModel : BaseModel<UniqueModel>
 {
 	[RequireUniqueChar()]
-	public string Unique1 { get; set; }
+	public string Unique1 { get; set; } = string.Empty;
 
 	[RequireUniqueChar(2)]
-	public string Unique2 { get; set; }
+	public string Unique2 { get; set; } = string.Empty;
 
 	[RequireUniqueChar(3)]
-	public string Unique3 { get; set; }
+	public string Unique3 { get; set; } = string.Empty;
 
 	[RequireUniqueChar(4)]
-	public string Unique4 { get; set; }
+	public string Unique4 { get; set; } = string.Empty;
 }

--- a/Validation/tests/Models/UppercaseModel.cs
+++ b/Validation/tests/Models/UppercaseModel.cs
@@ -7,5 +7,5 @@ namespace Wangkanai.Validation.Models;
 public class UppercaseModel : BaseModel<UppercaseModel>
 {
 	[RequireUppercase]
-	public string Password { get; set; }
+	public string Password { get; set; } = string.Empty;
 }

--- a/Validation/tests/RequireBooleanTests.cs
+++ b/Validation/tests/RequireBooleanTests.cs
@@ -1,7 +1,5 @@
 // Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-#nullable enable
-
 using System.Reflection;
 
 using Wangkanai.Validation.Extensions;
@@ -12,25 +10,19 @@ using Xunit.Abstractions;
 
 namespace Wangkanai.Validation;
 
-public class RequireBooleanTests
+public class RequireBooleanTests(ITestOutputHelper output)
 {
-	private readonly ITestOutputHelper _output;
-	private readonly PropertyInfo      _wannaFalse = BooleanModel.GetProperty(nameof(BooleanModel.WannaFalse));
-	private readonly PropertyInfo      _wannaTrue  = BooleanModel.GetProperty(nameof(BooleanModel.WannaTrue));
-	private readonly PropertyInfo      _nullableFalse  = BooleanModel.GetProperty(nameof(BooleanModel.NullableFalse));
+	private readonly PropertyInfo      _wannaFalse    = BooleanModel.GetProperty(nameof(BooleanModel.WannaFalse));
+	private readonly PropertyInfo      _wannaTrue     = BooleanModel.GetProperty(nameof(BooleanModel.WannaTrue));
+	private readonly PropertyInfo      _nullableFalse = BooleanModel.GetProperty(nameof(BooleanModel.NullableFalse));
 	private readonly PropertyInfo      _nullableTrue  = BooleanModel.GetProperty(nameof(BooleanModel.NullableTrue));
-
-	public RequireBooleanTests(ITestOutputHelper output)
-		=> _output = output;
 
 	[Fact]
 	public void ExpectedTrue_ActualTrue()
 	{
 		var vm = new BooleanModel { WannaTrue = true };
-
 		var validations = vm.Validate(vm.WannaTrue, _wannaTrue);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
 
@@ -38,10 +30,8 @@ public class RequireBooleanTests
 	public void ExpectedTrue_ActualFalse()
 	{
 		var vm = new BooleanModel { WannaTrue = false };
-
 		var validations = vm.Validate(vm.WannaTrue, _wannaTrue);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Collection(validations, v => v.ErrorMessage = "Checked is required");
 	}
 
@@ -49,10 +39,8 @@ public class RequireBooleanTests
 	public void ExpectedFalse_ActualTrue()
 	{
 		var vm = new BooleanModel { WannaFalse = true };
-
 		var validations = vm.Validate(vm.WannaFalse, _wannaFalse);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Collection(validations, v => v.ErrorMessage = "Unchecked is required");
 	}
 
@@ -60,32 +48,26 @@ public class RequireBooleanTests
 	public void ExpectedFalse_ActualFalse()
 	{
 		var vm = new BooleanModel { WannaTrue = false };
-
 		var validations = vm.Validate(vm.WannaFalse, _wannaFalse);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
-	
+
 	[Fact]
 	public void ExpectedTrue_ActualNull()
 	{
 		var vm = new BooleanModel { NullableTrue = null };
-
-		var validations = vm.Validate(vm.NullableTrue, _nullableTrue);
-		validations.Print(_output);
-
+		var validations = vm.Validate(vm.NullableTrue!, _nullableTrue);
+		validations.Print(output);
 		Assert.Collection(validations, v => v.ErrorMessage = "Checked is required");
 	}
-	
+
 	[Fact]
 	public void ExpectedFalse_ActualNull()
 	{
 		var vm = new BooleanModel { NullableFalse = null };
-
-		var validations = vm.Validate(vm.NullableFalse, _nullableFalse);
-		validations.Print(_output);
-
+		var validations = vm.Validate(vm.NullableFalse!, _nullableFalse);
+		validations.Print(output);
 		Assert.Collection(validations, v => v.ErrorMessage = "Unchecked is required");
 	}
 }

--- a/Validation/tests/RequireLowercaseTests.cs
+++ b/Validation/tests/RequireLowercaseTests.cs
@@ -10,70 +10,54 @@ using Xunit.Abstractions;
 
 namespace Wangkanai.Validation;
 
-public class RequireLowercaseTests
+public class RequireLowercaseTests(ITestOutputHelper output)
 {
-	private readonly ITestOutputHelper _output;
-	private readonly PropertyInfo      _password = LowercaseModel.GetProperty(nameof(LowercaseModel.Password));
-
-	public RequireLowercaseTests(ITestOutputHelper output)
-	{
-		_output = output;
-	}
+	private readonly PropertyInfo _password = LowercaseModel.GetProperty(nameof(LowercaseModel.Password));
 
 	[Fact]
 	public void Uppercase()
 	{
-		var vm = new LowercaseModel { Password = "ABC" };
-
+		var vm          = new LowercaseModel { Password = "ABC" };
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Collection(validations, v => v.ErrorMessage = "Lowercase is required");
 	}
 
 	[Fact]
 	public void Lowercase()
 	{
-		var vm = new LowercaseModel { Password = "abc" };
-
+		var vm          = new LowercaseModel { Password = "abc" };
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
 
 	[Fact]
 	public void Mix()
 	{
-		var vm = new LowercaseModel { Password = "Abc" };
-
+		var vm          = new LowercaseModel { Password = "Abc" };
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
-	
+
 	[Fact]
 	public void Unique()
 	{
 		var vm = new LowercaseModel { Password = "aaa" };
 
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
-	
+
 	[Fact]
 	public void Null()
 	{
-		var vm = new LowercaseModel { Password = null };
-
+		var vm          = new LowercaseModel { Password = null! };
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		// Assert.Collection(validations, v => v.ErrorMessage = "Lowercase is required");
 		Assert.Empty(validations); // This is not right!
 	}
-	
 }

--- a/Validation/tests/RequireUppercaseTest.cs
+++ b/Validation/tests/RequireUppercaseTest.cs
@@ -10,24 +10,16 @@ using Xunit.Abstractions;
 
 namespace Wangkanai.Validation;
 
-public class RequireUppercaseTest
+public class RequireUppercaseTest(ITestOutputHelper output)
 {
-	private readonly ITestOutputHelper _output;
-	private readonly PropertyInfo      _password = UppercaseModel.GetProperty(nameof(UppercaseModel.Password));
-
-	public RequireUppercaseTest(ITestOutputHelper output)
-	{
-		_output = output;
-	}
+	private readonly PropertyInfo _password = UppercaseModel.GetProperty(nameof(UppercaseModel.Password));
 
 	[Fact]
 	public void Uppercase()
 	{
-		var vm = new UppercaseModel { Password = "ABC" };
-
+		var vm          = new UppercaseModel { Password = "ABC" };
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
 
@@ -35,10 +27,8 @@ public class RequireUppercaseTest
 	public void Lowercase()
 	{
 		var vm = new UppercaseModel { Password = "abc" };
-
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Collection(validations, v => v.ErrorMessage = "Uppercase is required");
 	}
 
@@ -46,10 +36,8 @@ public class RequireUppercaseTest
 	public void Mix()
 	{
 		var vm = new UppercaseModel { Password = "Abc" };
-
 		var validations = vm.Validate(vm.Password, _password);
-		validations.Print(_output);
-
+		validations.Print(output);
 		Assert.Empty(validations);
 	}
 }


### PR DESCRIPTION
- warning CS8618: Non-nullable property 'Password' must contain a non-null value when exiting constructor. Consider declaring the property as nullable.