### PR TITLE
Publish production ready .NET 8 NuGet packages

### DIFF
--- a/Extensions/Directory.Build.props
+++ b/Extensions/Directory.Build.props
@@ -2,7 +2,6 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
 		<VersionPrefix>4.0.0</VersionPrefix>
-		<VersionSuffix>preview1</VersionSuffix>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Extensions</PackageProjectUrl>
 		<PackageNamespace>True</PackageNamespace>
 		<PackagePrimary>Internal</PackagePrimary>

--- a/Testing/Directory.Build.props
+++ b/Testing/Directory.Build.props
@@ -2,7 +2,6 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
 		<VersionPrefix>1.0.0</VersionPrefix>
-		<VersionSuffix>preview1</VersionSuffix>
 		<Title>Wangkanai Testing</Title>
 		<PackageTags>aspnetcore;testing</PackageTags>
 		<Description>This project is to turbocharge your .NET unit tests code coverage. It is a collection of helper classes and extension methods to help you write unit tests faster and easier.</Description>

--- a/Validation/Directory.Build.props
+++ b/Validation/Directory.Build.props
@@ -2,7 +2,6 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
 		<VersionPrefix>4.0.0</VersionPrefix>
-		<VersionSuffix>preview3</VersionSuffix>
 		<Title>Wangkanai Validation</Title>
 		<Description>Maintain data integrity with `Validation`, a robust .NET Data Annotation library. Enforce validation rules effortlessly, ensure data accuracy, and enhance your data validation process. Try it today and revolutionize your .NET projects</Description>
 		<PackageTags>aspnetcore;validation;</PackageTags>


### PR DESCRIPTION
The version suffix 'preview3' was removed from the validation properties file. This change reflects the transition from the preview phase to the ready-to-release phase for this specific .NET Data Annotation library.