### PR TITLE
Add optional name parameter to sign scripts

### DIFF
--- a/Analytics/sign.ps1
+++ b/Analytics/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Analytics/sign.ps1
+++ b/Analytics/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Analytics/sign.ps1
+++ b/Analytics/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Blazor/sign.ps1
+++ b/Blazor/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\Core\ -c Release -tl
 dotnet restore .\src\Core\
 dotnet build   .\src\Core\ -c Release -tl
 Get-ChildItem  .\src\Core\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\Core\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Blazor/sign.ps1
+++ b/Blazor/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Blazor/sign.ps1
+++ b/Blazor/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\Core\ -c Release -tl
 dotnet restore .\src\Core\
 dotnet build   .\src\Core\ -c Release -tl
-Get-ChildItem  .\src\Core\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\Core\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\Core\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Cryptography/sign.ps1
+++ b/Cryptography/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Cryptography/sign.ps1
+++ b/Cryptography/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Cryptography/sign.ps1
+++ b/Cryptography/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Detection/Directory.Build.props
+++ b/Detection/Directory.Build.props
@@ -1,9 +1,9 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>8.11.0</VersionPrefix>
+		<VersionPrefix>8.12.0</VersionPrefix>
 		<Title>Wangkanai Detection</Title>
-		<Description>Introducing `Detection` – your gateway to understanding your users' interactions with your ASP.NET Core application. With over 6.5 million downloads, `Detection` offers invaluable insights into your client's device, browser, engine, and platform, even identifying crawlers. Tailor your application to your users' needs, enhance the user experience, and optimize for SEO. Discover the power of `Detection` and let's create seamless, personalized experiences for all users.</Description>
+		<Description>Introducing `Detection` – your gateway to understanding your users' interactions with your ASP.NET Core application. With over 10 million downloads, `Detection` offers invaluable insights into your client's device, browser, engine, and platform, even identifying crawlers. Tailor your application to your users' needs, enhance the user experience, and optimize for SEO. Discover the power of `Detection` and let's create seamless, personalized experiences for all users.</Description>
 		<PackageTags>aspnetcore;detection;</PackageTags>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Detection</PackageProjectUrl>
 	</PropertyGroup>

--- a/Detection/sign.ps1
+++ b/Detection/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/Detection/sign.ps1
+++ b/Detection/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Detection/sign.ps1
+++ b/Detection/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Domain/sign.ps1
+++ b/Domain/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/Domain/sign.ps1
+++ b/Domain/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Domain/sign.ps1
+++ b/Domain/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/EntityFramework/sign.ps1
+++ b/EntityFramework/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/EntityFramework/sign.ps1
+++ b/EntityFramework/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/EntityFramework/sign.ps1
+++ b/EntityFramework/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Extensions/sign.ps1
+++ b/Extensions/sign.ps1
@@ -25,8 +25,8 @@ get-childitem .\ -directory | where { $_.Name -ne 'signed' } | where { $_.Name -
     dotnet clean   .\src\ -c Release -tl
     dotnet restore .\src\
     dotnet build   .\src\ -c Release -tl
-    Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-        signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
+    Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+        signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
     }
 
     dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Extensions/sign.ps1
+++ b/Extensions/sign.ps1
@@ -26,13 +26,13 @@ get-childitem .\ -directory | where { $_.Name -ne 'signed' } | where { $_.Name -
     dotnet restore .\src\
     dotnet build   .\src\ -c Release -tl
     Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-        signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n "Sarin Na Wangkanai" $_.FullName
+        signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
     }
 
     dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-    dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-    dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+    dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+    dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
     copy-item -path .\signed\*.* -destination .\..\signed\ -force
 

--- a/Extensions/sign.ps1
+++ b/Extensions/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Federation/sign.ps1
+++ b/Federation/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   Federation.slnf -c Release -tl
 dotnet restore Federation.slnf
 dotnet build   Federation.slnf -c Release -tl
-Get-ChildItem .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack Federation.slnf -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Federation/sign.ps1
+++ b/Federation/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   Federation.slnf -c Release -tl
 dotnet restore Federation.slnf
 dotnet build   Federation.slnf -c Release -tl
 Get-ChildItem .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack Federation.slnf -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Federation/sign.ps1
+++ b/Federation/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Hosting/sign.ps1
+++ b/Hosting/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Hosting/sign.ps1
+++ b/Hosting/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Hosting/sign.ps1
+++ b/Hosting/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Identity/sign.ps1
+++ b/Identity/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Identity/sign.ps1
+++ b/Identity/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Identity/sign.ps1
+++ b/Identity/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Markdown/sign.ps1
+++ b/Markdown/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Markdown/sign.ps1
+++ b/Markdown/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Markdown/sign.ps1
+++ b/Markdown/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Mvc/sign.ps1
+++ b/Mvc/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Mvc/sign.ps1
+++ b/Mvc/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Mvc/sign.ps1
+++ b/Mvc/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Responsive/sign.ps1
+++ b/Responsive/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Responsive/sign.ps1
+++ b/Responsive/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Responsive/sign.ps1
+++ b/Responsive/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Security/sign.ps1
+++ b/Security/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   Security.slnf -c Release -tl
 dotnet restore Security.slnf
 dotnet build   Security.slnf -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack Security.slnf -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Security/sign.ps1
+++ b/Security/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   Security.slnf -c Release -tl
 dotnet restore Security.slnf
 dotnet build   Security.slnf -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
 }
 
 dotnet pack Security.slnf -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Security/sign.ps1
+++ b/Security/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Solver/sign.ps1
+++ b/Solver/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Solver/sign.ps1
+++ b/Solver/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Solver/sign.ps1
+++ b/Solver/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/System/sign.ps1
+++ b/System/sign.ps1
@@ -16,13 +16,13 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/System/sign.ps1
+++ b/System/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/System/sign.ps1
+++ b/System/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Tabler/sign.ps1
+++ b/Tabler/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\Core\ -c Release -tl
 dotnet restore .\src\Core\
 dotnet build   .\src\Core\ -c Release -tl
-Get-ChildItem  .\src\Core\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\Core\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\Core\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/Tabler/sign.ps1
+++ b/Tabler/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\Core\ -c Release -tl
 dotnet restore .\src\Core\
 dotnet build   .\src\Core\ -c Release -tl
 Get-ChildItem  .\src\Core\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\Core\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Tabler/sign.ps1
+++ b/Tabler/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Testing/sign.ps1
+++ b/Testing/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Testing/sign.ps1
+++ b/Testing/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/Testing/sign.ps1
+++ b/Testing/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Tools/sign.ps1
+++ b/Tools/sign.ps1
@@ -25,8 +25,8 @@ get-childitem .\ -directory | where { $_.Name -ne 'signed' } | where { $_.Name -
     dotnet clean   .\src\ -c Release -tl
     dotnet restore .\src\
     dotnet build   .\src\ -c Release -tl
-    Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-        signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
+    Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+        signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
     }
 
     dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Tools/sign.ps1
+++ b/Tools/sign.ps1
@@ -26,13 +26,13 @@ get-childitem .\ -directory | where { $_.Name -ne 'signed' } | where { $_.Name -
     dotnet restore .\src\
     dotnet build   .\src\ -c Release -tl
     Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-        signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n "Sarin Na Wangkanai" $_.FullName
+        signtool sign /fd SHA256 /tr http://ts.ssl.com /td sha256 /n $name $_.FullName
     }
 
     dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-    dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-    dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+    dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+    dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
     copy-item -path .\signed\*.* -destination .\..\signed\ -force
 

--- a/Tools/sign.ps1
+++ b/Tools/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Validation/sign.ps1
+++ b/Validation/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Validation/sign.ps1
+++ b/Validation/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/Validation/sign.ps1
+++ b/Validation/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Webmaster/sign.ps1
+++ b/Webmaster/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Webmaster/sign.ps1
+++ b/Webmaster/sign.ps1
@@ -12,13 +12,13 @@ new-item -Path artifacts -ItemType Directory -Force | out-null
 new-item -Path signed    -ItemType Directory -Force | out-null
 
 dotnet --version
-dotnet clean   .\src\ -c Release -tl
+dotnet clean   .\src\ -c Release
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
     signtool sign /fd SHA256 /n $name $_.FullName
 }
-dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
+dotnet pack .\src\ -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed

--- a/Webmaster/sign.ps1
+++ b/Webmaster/sign.ps1
@@ -15,8 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/Webmaster/sign.ps1
+++ b/Webmaster/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Webserver/Directory.Build.props
+++ b/Webserver/Directory.Build.props
@@ -1,22 +1,22 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-	
+
 	<PropertyGroup>
-		<VersionPrefix>3.8.0</VersionPrefix>
+		<VersionPrefix>3.7.0</VersionPrefix>
 		<Title>Wangkanai Webserver</Title>
 		<Description>ASP.NET Core extension library that streamlines your server setup process. Simplify your configuration, make your server more resilient, and create a more enjoyable development experience. This is the tool you need to take your web development to the next level.</Description>
 		<PackageTags>aspnetcore;webserver;</PackageTags>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Webserver</PackageProjectUrl>
 	</PropertyGroup>
-	
+
 	<PropertyGroup>
 		<PackageIcon>wangkanai-logo.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	
+
 	<ItemGroup>
 		<None Include="..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
-	
+
 </Project>

--- a/Webserver/sign.ps1
+++ b/Webserver/sign.ps1
@@ -16,12 +16,12 @@ dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n "Sarin Na Wangkanai" $_.FullName
+    signtool sign /fd SHA256 /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal -tl --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal -tl --timestamper http://timestamp.digicert.com --certificate-subject-name "Sarin Na Wangkanai" -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal -tl --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal -tl --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Webserver/sign.ps1
+++ b/Webserver/sign.ps1
@@ -17,11 +17,12 @@ dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
     signtool sign /fd SHA256 /n $name $_.FullName
+    #    codesign -s /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
-dotnet nuget sign .\artifacts\*.nupkg  -v normal -tl --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
-dotnet nuget sign .\artifacts\*.snupkg -v normal -tl --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
+dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
 if ($dryrun)
 {

--- a/Webserver/sign.ps1
+++ b/Webserver/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false
+    [bool]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$name="Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Webserver/sign.ps1
+++ b/Webserver/sign.ps1
@@ -15,9 +15,8 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Name -like "*release*" } | foreach {
-    signtool sign /fd SHA256 /n $name $_.FullName
-    #    codesign -s /n $name $_.FullName
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
+    signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 

--- a/sign.ps1
+++ b/sign.ps1
@@ -1,6 +1,8 @@
 param(
     [Parameter(mandatory=$false)]
-    [switch]$dryrun=$false
+    [switch]$dryrun=$false,
+    [Parameter(mandatory=$false)]
+    [string]$certicate="Open Source Developer, Sarin Na Wangkanai"
 )
 
 $dirs=[ordered]@{
@@ -29,7 +31,7 @@ $dirs=[ordered]@{
 }
 
 $e=[char]27
-$root="D:\Sources\Wangkanai\"
+$root="~/sources/wangkanai"
 
 Set-Location -Path $root
 
@@ -68,7 +70,7 @@ for ($i=0; $i -lt $dirs.count; $i++) {
         if ($latest -ne $version)
         {
             Write-Host $latest " < " $version " Update" -ForegroundColor Green;
-            .\sign.ps1 -dryrun $dryrun
+            .\sign.ps1 -dryrun $dryrun -name $certicate
         }
         else
         {
@@ -78,7 +80,7 @@ for ($i=0; $i -lt $dirs.count; $i++) {
     catch
     {
         Write-Host "New " $latest -ForegroundColor Blue;
-        .\sign.ps1 -dryrun $dryrun
+        .\sign.ps1 -dryrun $dryrun -name $certicate
     }
 
     Pop-Location;

--- a/sign.ps1
+++ b/sign.ps1
@@ -31,7 +31,7 @@ $dirs=[ordered]@{
 }
 
 $e=[char]27
-$root="~/sources/wangkanai"
+$root="D:\Sources\wangkanai"
 
 Set-Location -Path $root
 


### PR DESCRIPTION
The sign.ps1 scripts have been updated across multiple projects (Blazor, Detection, Analytics, Cryptography) to include an optional 'name' parameter. This allows the users to specify a name while running the script. The root path has also been updated in sign.ps1 for general script improvements and better path handling.