### PR TITLE
Refactor code to expect non-null values

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -108,7 +108,7 @@ indent_size                           =4
 ij_html_do_not_indent_children_of_tags=none
 
 [*.csproj]
-indent_size                  =4
+indent_size                  =2
 ij_xml_space_inside_empty_tag=true
 
 [*.{props, targets}]

--- a/System/src/Attributes/DeprecateAttribute.cs
+++ b/System/src/Attributes/DeprecateAttribute.cs
@@ -2,8 +2,7 @@
 
 namespace Wangkanai;
 
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate,
-	Inherited = false)]
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate, Inherited = false)]
 public sealed class DeprecateAttribute : Attribute
 {
 	public string? Message { get; }
@@ -18,16 +17,15 @@ public sealed class DeprecateAttribute : Attribute
 		=> IsError = error;
 }
 
-[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate,
-	Inherited = false)]
-public class DeprecateAttribute<TNew> : Attribute
+[AttributeUsage(AttributeTargets.Class | AttributeTargets.Struct | AttributeTargets.Enum | AttributeTargets.Interface | AttributeTargets.Constructor | AttributeTargets.Method | AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Event | AttributeTargets.Delegate, Inherited = false)]
+public sealed class DeprecateAttribute<T> : Attribute
 {
 	public string? Replacement { get; }
 	public string? Message     { get; }
 	public bool    IsError     { get; }
 
 	public DeprecateAttribute()
-		=> Replacement = typeof(TNew).Name;
+		=> Replacement = typeof(T).Name;
 
 	public DeprecateAttribute(string? message)
 		=> Message = message;

--- a/System/src/Attributes/NotNullAttribute.cs
+++ b/System/src/Attributes/NotNullAttribute.cs
@@ -1,6 +1,0 @@
-// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
-
-namespace Wangkanai;
-
-[AttributeUsage(AttributeTargets.All)]
-public sealed class NotNullAttribute : Attribute { }

--- a/System/src/Attributes/PositiveIntegerAttribute.cs
+++ b/System/src/Attributes/PositiveIntegerAttribute.cs
@@ -3,4 +3,4 @@
 namespace Wangkanai;
 
 [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Parameter)]
-public class NegativeIntegerAttribute : Attribute { }
+public class PositiveIntegerAttribute : Attribute { }

--- a/System/src/Checks/ExceptionActivator.cs
+++ b/System/src/Checks/ExceptionActivator.cs
@@ -6,25 +6,17 @@ internal static class ExceptionActivator
 {
 	internal static T CreateGenericInstance<T>(string paramName)
 		where T : Exception
-	{
-		return (Activator.CreateInstance(typeof(T), paramName) as T)!;
-	}
+		=> (Activator.CreateInstance(typeof(T), paramName) as T)!;
 
 	internal static T CreateGenericInstance<T>(string paramName, string message)
 		where T : Exception
-	{
-		return (Activator.CreateInstance(typeof(T), paramName, message) as T)!;
-	}
+		=> (Activator.CreateInstance(typeof(T), paramName, message) as T)!;
 
 	internal static T CreateArgumentInstance<T>(string paramName)
 		where T : ArgumentException
-	{
-		return (Activator.CreateInstance(typeof(T), paramName) as T)!;
-	}
+		=> (Activator.CreateInstance(typeof(T), paramName) as T)!;
 
 	internal static T CreateArgumentInstance<T>(string paramName, string message)
 		where T : ArgumentException
-	{
-		return (Activator.CreateInstance(typeof(T), paramName, message) as T)!;
-	}
+		=> (Activator.CreateInstance(typeof(T), paramName, message) as T)!;
 }

--- a/System/src/Checks/NullConditionalExtensions.cs
+++ b/System/src/Checks/NullConditionalExtensions.cs
@@ -6,10 +6,10 @@ namespace Wangkanai;
 public static class NullConditionalExtensions
 {
 	[return: NotNull]
-	public static bool TrueIfNull<T>(this T? value)
+	public static bool TrueIfNull<T>([NotNull] this T? value)
 		=> value is null;
 
 	[return: NotNull]
-	public static bool FalseIfNull<T>(this T? value)
+	public static bool FalseIfNull<T>([NotNull] this T? value)
 		=> value is not null;
 }

--- a/System/src/Checks/ThrowIfEmptyEnumerableExtensions.cs
+++ b/System/src/Checks/ThrowIfEmptyEnumerableExtensions.cs
@@ -1,11 +1,6 @@
 // Copyright (c) 2014-2024 Sarin Na Wangkanai,All Rights Reserved.Apache License,Version 2.0
 
-using System.Diagnostics.CodeAnalysis;
-
 using Wangkanai.Exceptions;
-
-#pragma warning disable CS8603 // Possible null reference return.
-#pragma warning disable CS8604 // Possible null reference argument.
 
 namespace Wangkanai;
 
@@ -13,21 +8,17 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfEmptyExtensions
 {
-	public static IEnumerable<T> ThrowIfEmpty<T>(this IEnumerable<T>? value)
-	{
-		return !value.ThrowIfNull().Any()
-			       ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value))
-			       : value;
-	}
+	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T>? value)
+		=> !value.ThrowIfNull().Any()
+			   ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value))
+			   : value;
 
-	public static IEnumerable<T> ThrowIfEmpty<T>(this IEnumerable<T>? value, string message)
-	{
-		return !value.ThrowIfNull().Any()
-			       ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value), message)
-			       : value;
-	}
+	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T>? value, string message)
+		=> !value.ThrowIfNull().Any()
+			   ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value), message)
+			   : value;
 
-	public static IEnumerable<TType> ThrowIfEmpty<TException, TType>(this IEnumerable<TType>? value)
+	public static IEnumerable<TType> ThrowIfEmpty<TException, TType>([NotNull] this IEnumerable<TType>? value)
 		where TException : ArgumentException
 	{
 		value.ThrowIfNull<TException>();
@@ -36,7 +27,7 @@ public static class ThrowIfEmptyExtensions
 			       : value;
 	}
 
-	public static IEnumerable<TType> ThrowIfEmpty<TException, TType>(this IEnumerable<TType>? value, string message)
+	public static IEnumerable<TType> ThrowIfEmpty<TException, TType>([NotNull] this IEnumerable<TType>? value, string message)
 		where TException : ArgumentException
 	{
 		value.ThrowIfNull<TException>();

--- a/System/src/Checks/ThrowIfEmptyStringExtensions.cs
+++ b/System/src/Checks/ThrowIfEmptyStringExtensions.cs
@@ -8,25 +8,25 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfEmptyStringExtensions
 {
-	public static string ThrowIfEmpty(this string? value)
+	public static string ThrowIfEmpty([NotNull] this string? value)
 		=> value.ThrowIfNull().ThrowIfEmpty<ArgumentEmptyException>();
 
-	public static string ThrowIfEmpty(this string? value, string message)
+	public static string ThrowIfEmpty([NotNull] this string? value, string message)
 		=> value.ThrowIfNull().ThrowIfEmpty<ArgumentEmptyException>(message);
 
-	public static string ThrowIfEmpty<T>(this string? value)
+	public static string ThrowIfEmpty<T>([NotNull] this string? value)
 		where T : ArgumentException
 		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value))
 			   : value!;
 
-	public static string ThrowIfEmpty<T>(this string? value, string message)
+	public static string ThrowIfEmpty<T>([NotNull] this string? value, string message)
 		where T : ArgumentException
 		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message)
 			   : value!;
 
-	public static string ThrowIfEmpty<T>(this string? value, string message, string paramName)
+	public static string ThrowIfEmpty<T>([NotNull] this string? value, string message, string paramName)
 		where T : ArgumentException
 		=> value.ThrowIfNull<T>().IsEmpty()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName, message)

--- a/System/src/Checks/ThrowIfEqualExtensions.cs
+++ b/System/src/Checks/ThrowIfEqualExtensions.cs
@@ -7,18 +7,18 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfEqualExtensions
 {
-	public static bool ThrowIfEqual(this int value, int expected)
+	public static bool ThrowIfEqual([NotNull] this int value, int expected)
 	{
 		return value.ThrowIfEqual<ArgumentEqualException>(expected, nameof(value));
 	}
 
-	public static bool ThrowIfEqual<T>(this int value, int expected)
+	public static bool ThrowIfEqual<T>([NotNull] this int value, int expected)
 		where T : ArgumentException
 	{
 		return value.ThrowIfEqual<T>(expected, nameof(value));
 	}
 
-	public static bool ThrowIfEqual<T>(this int value, int expected, string paramName)
+	public static bool ThrowIfEqual<T>([NotNull] this int value, int expected, string paramName)
 		where T : ArgumentException
 	{
 		return value == expected

--- a/System/src/Checks/ThrowIfLessThanExtensions.cs
+++ b/System/src/Checks/ThrowIfLessThanExtensions.cs
@@ -7,27 +7,19 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfLessThanExtensions
 {
-	public static bool ThrowIfLessThan(this int value, int expected)
-	{
-		return value.ThrowIfLessThan<ArgumentLessThanException>(expected, nameof(value));
-	}
+	public static bool ThrowIfLessThan([NotNull] this int value, int expected)
+		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, nameof(value));
 
-	public static bool ThrowIfLessThan(this int value, int expected, string message)
-	{
-		return value.ThrowIfLessThan<ArgumentLessThanException>(expected, message);
-	}
+	public static bool ThrowIfLessThan([NotNull] this int value, int expected, string message)
+		=> value.ThrowIfLessThan<ArgumentLessThanException>(expected, message);
 
-	public static bool ThrowIfLessThan<T>(this int value, int expected)
+	public static bool ThrowIfLessThan<T>([NotNull] this int value, int expected)
 		where T : ArgumentException
-	{
-		return value.ThrowIfLessThan<T>(expected, nameof(value));
-	}
+		=> value.ThrowIfLessThan<T>(expected, nameof(value));
 
-	public static bool ThrowIfLessThan<T>(this int value, int expected, string message)
+	public static bool ThrowIfLessThan<T>([NotNull] this int value, int expected, string message)
 		where T : ArgumentException
-	{
-		return value < expected
-			       ? throw ExceptionActivator.CreateArgumentInstance<T>(message)
-			       : true;
-	}
+		=> value < expected
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(message)
+			   : true;
 }

--- a/System/src/Checks/ThrowIfMoreThanExtensions.cs
+++ b/System/src/Checks/ThrowIfMoreThanExtensions.cs
@@ -6,27 +6,19 @@ namespace Wangkanai;
 
 public static class ThrowIfMoreThanExtensions
 {
-	public static bool ThrowIfMoreThan(this int value, int expected)
-	{
-		return value.ThrowIfMoreThan<ArgumentMoreThanException>(expected);
-	}
+	public static bool ThrowIfMoreThan([NotNull] this int value, int expected)
+		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected);
 
-	public static bool ThrowIfMoreThan(this int value, int expected, string message)
-	{
-		return value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, message);
-	}
+	public static bool ThrowIfMoreThan([NotNull] this int value, int expected, string message)
+		=> value.ThrowIfMoreThan<ArgumentMoreThanException>(expected, message);
 
-	public static bool ThrowIfMoreThan<T>(this int value, int expected)
+	public static bool ThrowIfMoreThan<T>([NotNull] this int value, int expected)
 		where T : ArgumentException
-	{
-		return value.ThrowIfMoreThan<T>(expected, nameof(value));
-	}
+		=> value.ThrowIfMoreThan<T>(expected, nameof(value));
 
-	public static bool ThrowIfMoreThan<T>(this int value, int expected, string message)
+	public static bool ThrowIfMoreThan<T>([NotNull] this int value, int expected, string message)
 		where T : ArgumentException
-	{
-		return value > expected
-			       ? throw ExceptionActivator.CreateArgumentInstance<T>(message)
-			       : true;
-	}
+		=> value > expected
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(message)
+			   : true;
 }

--- a/System/src/Checks/ThrowIfNegativeExtensions.cs
+++ b/System/src/Checks/ThrowIfNegativeExtensions.cs
@@ -7,17 +7,17 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfNegativeExtensions
 {
-	public static int ThrowIfNegative(this int value)
+	public static int ThrowIfNegative([NotNull] this int value)
 		=> value.ThrowIfNegative<ArgumentNegativeException>();
 
-	public static int ThrowIfNegative(this int value, string message)
+	public static int ThrowIfNegative([NotNull] this int value, string message)
 		=> value.ThrowIfNegative<ArgumentNegativeException>(message);
 
-	public static int ThrowIfNegative<T>(this int value)
+	public static int ThrowIfNegative<T>([NotNull] this int value)
 		where T : ArgumentException
 		=> value.ThrowIfNegative<T>(nameof(value));
 
-	public static int ThrowIfNegative<T>(this int value, string message)
+	public static int ThrowIfNegative<T>([NotNull] this int value, string message)
 		where T : ArgumentException
 		=> value < 0
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message)

--- a/System/src/Checks/ThrowIfNotEqualExtensions.cs
+++ b/System/src/Checks/ThrowIfNotEqualExtensions.cs
@@ -7,14 +7,14 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfNotEqualExtensions
 {
-	public static bool ThrowIfNotEqual(this int value, int expected)
+	public static bool ThrowIfNotEqual([NotNull] this int value, int expected)
 		=> value.ThrowIfNotEqual<ArgumentNotEqualException>(expected, nameof(value));
 
-	public static bool ThrowIfNotEqual<T>(this int value, int expected)
+	public static bool ThrowIfNotEqual<T>([NotNull] this int value, int expected)
 		where T : ArgumentException
 		=> value.ThrowIfNotEqual<T>(expected, nameof(value));
 
-	public static bool ThrowIfNotEqual<T>(this int value, int expected, string paramName)
+	public static bool ThrowIfNotEqual<T>([NotNull] this int value, int expected, string paramName)
 		where T : ArgumentException
 		=> value != expected
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName)

--- a/System/src/Checks/ThrowIfNullExtensions.cs
+++ b/System/src/Checks/ThrowIfNullExtensions.cs
@@ -7,91 +7,91 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class CheckThrowIfNullExtensions
 {
-	public static bool    ThrowIfNull(this bool?    value) => ThrowIfNull<ArgumentNullException>(value);
-	public static byte    ThrowIfNull(this byte?    value) => ThrowIfNull<ArgumentNullException>(value);
-	public static sbyte   ThrowIfNull(this sbyte?   value) => ThrowIfNull<ArgumentNullException>(value);
-	public static short   ThrowIfNull(this short?   value) => ThrowIfNull<ArgumentNullException>(value);
-	public static ushort  ThrowIfNull(this ushort?  value) => ThrowIfNull<ArgumentNullException>(value);
-	public static int     ThrowIfNull(this int?     value) => ThrowIfNull<ArgumentNullException>(value);
-	public static uint    ThrowIfNull(this uint?    value) => ThrowIfNull<ArgumentNullException>(value);
-	public static nint    ThrowIfNull(this nint?    value) => ThrowIfNull<ArgumentNullException>(value);
-	public static nuint   ThrowIfNull(this nuint?   value) => ThrowIfNull<ArgumentNullException>(value);
-	public static long    ThrowIfNull(this long?    value) => ThrowIfNull<ArgumentNullException>(value);
-	public static ulong   ThrowIfNull(this ulong?   value) => ThrowIfNull<ArgumentNullException>(value);
-	public static float   ThrowIfNull(this float?   value) => ThrowIfNull<ArgumentNullException>(value);
-	public static decimal ThrowIfNull(this decimal? value) => ThrowIfNull<ArgumentNullException>(value);
-	public static double  ThrowIfNull(this double?  value) => ThrowIfNull<ArgumentNullException>(value);
-	public static char    ThrowIfNull(this char?    value) => ThrowIfNull<ArgumentNullException>(value);
-	public static string  ThrowIfNull(this string?  value) => ThrowIfNull<ArgumentNullException>(value);
+	public static bool    ThrowIfNull([NotNull] this bool?    value) => ThrowIfNull<ArgumentNullException>(value);
+	public static byte    ThrowIfNull([NotNull] this byte?    value) => ThrowIfNull<ArgumentNullException>(value);
+	public static sbyte   ThrowIfNull([NotNull] this sbyte?   value) => ThrowIfNull<ArgumentNullException>(value);
+	public static short   ThrowIfNull([NotNull] this short?   value) => ThrowIfNull<ArgumentNullException>(value);
+	public static ushort  ThrowIfNull([NotNull] this ushort?  value) => ThrowIfNull<ArgumentNullException>(value);
+	public static int     ThrowIfNull([NotNull] this int?     value) => ThrowIfNull<ArgumentNullException>(value);
+	public static uint    ThrowIfNull([NotNull] this uint?    value) => ThrowIfNull<ArgumentNullException>(value);
+	public static nint    ThrowIfNull([NotNull] this nint?    value) => ThrowIfNull<ArgumentNullException>(value);
+	public static nuint   ThrowIfNull([NotNull] this nuint?   value) => ThrowIfNull<ArgumentNullException>(value);
+	public static long    ThrowIfNull([NotNull] this long?    value) => ThrowIfNull<ArgumentNullException>(value);
+	public static ulong   ThrowIfNull([NotNull] this ulong?   value) => ThrowIfNull<ArgumentNullException>(value);
+	public static float   ThrowIfNull([NotNull] this float?   value) => ThrowIfNull<ArgumentNullException>(value);
+	public static decimal ThrowIfNull([NotNull] this decimal? value) => ThrowIfNull<ArgumentNullException>(value);
+	public static double  ThrowIfNull([NotNull] this double?  value) => ThrowIfNull<ArgumentNullException>(value);
+	public static char    ThrowIfNull([NotNull] this char?    value) => ThrowIfNull<ArgumentNullException>(value);
+	public static string  ThrowIfNull([NotNull] this string?  value) => ThrowIfNull<ArgumentNullException>(value);
 
-	public static string ThrowIfNull(this string? value, string message)
+	public static string ThrowIfNull([NotNull] this string? value, string message)
 		=> ThrowIfNull<ArgumentNullException>(value, message);
 
-	public static bool ThrowIfNull<T>(this bool? value)
+	public static bool ThrowIfNull<T>([NotNull] this bool? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static sbyte ThrowIfNull<T>(this sbyte? value)
+	public static sbyte ThrowIfNull<T>([NotNull] this sbyte? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static byte ThrowIfNull<T>(this byte? value)
+	public static byte ThrowIfNull<T>([NotNull] this byte? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static short ThrowIfNull<T>(this short? value)
+	public static short ThrowIfNull<T>([NotNull] this short? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static ushort ThrowIfNull<T>(this ushort? value)
+	public static ushort ThrowIfNull<T>([NotNull] this ushort? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static int ThrowIfNull<T>(this int? value)
+	public static int ThrowIfNull<T>([NotNull] this int? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static uint ThrowIfNull<T>(this uint? value)
+	public static uint ThrowIfNull<T>([NotNull] this uint? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static nint ThrowIfNull<T>(this nint? value)
+	public static nint ThrowIfNull<T>([NotNull] this nint? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static nuint ThrowIfNull<T>(this nuint? value)
+	public static nuint ThrowIfNull<T>([NotNull] this nuint? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static long ThrowIfNull<T>(this long? value)
+	public static long ThrowIfNull<T>([NotNull] this long? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static ulong ThrowIfNull<T>(this ulong? value)
+	public static ulong ThrowIfNull<T>([NotNull] this ulong? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static float ThrowIfNull<T>(this float? value)
+	public static float ThrowIfNull<T>([NotNull] this float? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static double ThrowIfNull<T>(this double? value)
+	public static double ThrowIfNull<T>([NotNull] this double? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static decimal ThrowIfNull<T>(this decimal? value)
+	public static decimal ThrowIfNull<T>([NotNull] this decimal? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static char ThrowIfNull<T>(this char? value)
+	public static char ThrowIfNull<T>([NotNull] this char? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static string ThrowIfNull<T>(this string? value)
+	public static string ThrowIfNull<T>([NotNull] this string? value)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
 
-	public static string ThrowIfNull<T>(this string? value, string message)
+	public static string ThrowIfNull<T>([NotNull] this string? value, string message)
 		where T : ArgumentException
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message);
 }

--- a/System/src/Checks/ThrowIfNullGenericExtensions.cs
+++ b/System/src/Checks/ThrowIfNullGenericExtensions.cs
@@ -5,9 +5,9 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfNullGenericExtensions
 {
-	public static T ThrowIfNull<T>(this T value)
+	public static T ThrowIfNull<T>([NotNull] this T value)
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<ArgumentNullException>(nameof(value));
 
-	public static T ThrowIfNull<T>(this T value, string message)
+	public static T ThrowIfNull<T>([NotNull] this T value, string message)
 		=> value ?? throw ExceptionActivator.CreateArgumentInstance<ArgumentNullException>(nameof(value), message);
 }

--- a/System/src/Checks/ThrowIfNullObjectExtensions.cs
+++ b/System/src/Checks/ThrowIfNullObjectExtensions.cs
@@ -6,11 +6,11 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfNullObjectExtensions
 {
-	public static object ThrowIfNull<T>(this object? value)
+	public static object ThrowIfNull<T>([NotNull] this object? value)
 		where T : Exception
 		=> value ?? throw ExceptionActivator.CreateGenericInstance<T>(nameof(value));
 
-	public static object ThrowIfNull<T>(this object? value, string message)
+	public static object ThrowIfNull<T>([NotNull] this object? value, string message)
 		where T : Exception
 		=> value ?? throw ExceptionActivator.CreateGenericInstance<T>(nameof(value), message);
 }

--- a/System/src/Checks/ThrowIfNullOrEmptyExtensions.cs
+++ b/System/src/Checks/ThrowIfNullOrEmptyExtensions.cs
@@ -8,34 +8,28 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfNullOrEmptyExtensions
 {
-	public static string ThrowIfNullOrEmpty(this string? value)
+	public static string ThrowIfNullOrEmpty([NotNull] this string? value)
 		=> value.ThrowIfNullOrEmpty<ArgumentNullOrEmptyException>();
-	public static string ThrowIfNullOrEmpty(this string? value, string message)
+	public static string ThrowIfNullOrEmpty([NotNull] this string? value, string message)
 		=> value.ThrowIfNullOrEmpty<ArgumentNullOrEmptyException>(message);
-	public static string ThrowIfNullOrEmpty(this string? value, string message, string paramName)
+	public static string ThrowIfNullOrEmpty([NotNull] this string? value, string message, string paramName)
 		=> value.ThrowIfNullOrEmpty<ArgumentNullOrEmptyException>(message, paramName);
 
-	public static string ThrowIfNullOrEmpty<T>(this string? value)
+	public static string ThrowIfNullOrEmpty<T>([NotNull] this string? value)
 		where T : ArgumentException
-	{
-		if (value!.IsNullOrEmpty())
-			throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value));
-		return value!;
-	}
+		=> value!.IsNullOrEmpty()
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value))
+			   : value!;
 
-	public static string ThrowIfNullOrEmpty<T>(this string? value, string message)
+	public static string ThrowIfNullOrEmpty<T>([NotNull] this string? value, string message)
 		where T : ArgumentException
-	{
-		if (value!.IsNullOrEmpty())
-			throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message);
-		return value!;
-	}
+		=> value!.IsNullOrEmpty()
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message)
+			   : value!;
 
-	public static string ThrowIfNullOrEmpty<T>(this string? value, string message,  string paramName)
+	public static string ThrowIfNullOrEmpty<T>([NotNull] this string? value, string message,  string paramName)
 		where T : ArgumentException
-	{
-		if (value!.IsNullOrEmpty())
-			throw ExceptionActivator.CreateArgumentInstance<T>(paramName, message);
-		return value!;
-	}
+		=> value!.IsNullOrEmpty()
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName, message)
+			   : value!;
 }

--- a/System/src/Checks/ThrowIfNullOrWhitespaceExtensions.cs
+++ b/System/src/Checks/ThrowIfNullOrWhitespaceExtensions.cs
@@ -8,21 +8,21 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfNullOrWhitespaceExtensions
 {
-	public static string ThrowIfNullOrWhitespace(this string? value)
+	public static string ThrowIfNullOrWhitespace([NotNull] this string? value)
 		=> value.ThrowIfNullOrWhitespace<ArgumentNullOrWhitespaceException>();
 
-	public static string ThrowIfNullOrWhitespace(this string? value, string message)
+	public static string ThrowIfNullOrWhitespace([NotNull] this string? value, string message)
 		=> value.ThrowIfNullOrWhitespace<ArgumentNullOrWhitespaceException>(message);
 
-	public static string ThrowIfNullOrWhitespace<T>(this string? value)
+	public static string ThrowIfNullOrWhitespace<T>([NotNull] this string? value)
 		where T : ArgumentException
 		=> value.ThrowIfNullOrWhitespace<T>(nameof(value));
 
-	public static string ThrowIfNullOrWhitespace<T>(this string? value, string message)
+	public static string ThrowIfNullOrWhitespace<T>([NotNull] this string? value, string message)
 		where T : ArgumentException
 		=> value.ThrowIfNullOrWhitespace<T>(message, nameof(value));
 
-	public static string ThrowIfNullOrWhitespace<T>(this string? value, string message, string paramName)
+	public static string ThrowIfNullOrWhitespace<T>([NotNull] this string? value, string message, string paramName)
 		where T : ArgumentException
 		=> value!.IsNullOrWhiteSpace()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName, message)

--- a/System/src/Checks/ThrowIfOutOfRangeExtension.cs
+++ b/System/src/Checks/ThrowIfOutOfRangeExtension.cs
@@ -7,7 +7,7 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfOutOfRangeExtension
 {
-	public static T ThrowIfOutOfRange<T>(this T index, [PositiveInteger] T lower, [PositiveInteger] T upper)
+	public static T ThrowIfOutOfRange<T>([NotNull] this T index, [PositiveInteger] T lower, [PositiveInteger] T upper)
 		where T : IBinaryInteger<T>
 		=> index < lower || index >= upper
 			   ? throw new ArgumentOutOfRangeException(nameof(index))

--- a/System/src/Checks/ThrowIfPositiveExtensions.cs
+++ b/System/src/Checks/ThrowIfPositiveExtensions.cs
@@ -7,27 +7,19 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfPositiveExtensions
 {
-	public static int ThrowIfPositive(this int value)
-	{
-		return value.ThrowIfPositive<ArgumentPositiveException>();
-	}
+	public static int ThrowIfPositive([NotNull] this int value)
+		=> value.ThrowIfPositive<ArgumentPositiveException>();
 
-	public static int ThrowIfPositive(this int value, string message)
-	{
-		return value.ThrowIfPositive<ArgumentPositiveException>(message);
-	}
+	public static int ThrowIfPositive([NotNull] this int value, string message)
+		=> value.ThrowIfPositive<ArgumentPositiveException>(message);
 
-	public static int ThrowIfPositive<T>(this int value)
+	public static int ThrowIfPositive<T>([NotNull] this int value)
 		where T : ArgumentException
-	{
-		return value.ThrowIfPositive<T>(nameof(value));
-	}
+		=> value.ThrowIfPositive<T>(nameof(value));
 
-	public static int ThrowIfPositive<T>(this int value, string message)
+	public static int ThrowIfPositive<T>([NotNull] this int value, string message)
 		where T : ArgumentException
-	{
-		return value > 0
-			       ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message)
-			       : value;
-	}
+		=> value > 0
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message)
+			   : value;
 }

--- a/System/src/Checks/ThrowIfWhitespaceExtensions.cs
+++ b/System/src/Checks/ThrowIfWhitespaceExtensions.cs
@@ -8,21 +8,21 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfWhitespaceExtensions
 {
-	public static string ThrowIfWhitespace(this string? value)
+	public static string ThrowIfWhitespace([NotNull] this string? value)
 		=> value.ThrowIfWhitespace<ArgumentWhitespaceException>();
 
-	public static string ThrowIfWhitespace(this string? value, string message)
+	public static string ThrowIfWhitespace([NotNull] this string? value, string message)
 		=> value.ThrowIfWhitespace<ArgumentWhitespaceException>(message);
 
-	public static string ThrowIfWhitespace<T>(this string? value)
+	public static string ThrowIfWhitespace<T>([NotNull] this string? value)
 		where T : ArgumentException
 		=> value.ThrowIfWhitespace<T>(nameof(value));
 
-	public static string ThrowIfWhitespace<T>(this string? value, string message)
+	public static string ThrowIfWhitespace<T>([NotNull] this string? value, string message)
 		where T : ArgumentException
 		=> value.ThrowIfWhitespace<T>(message, nameof(value));
 
-	public static string ThrowIfWhitespace<T>(this string? value, string message, string paramName)
+	public static string ThrowIfWhitespace<T>([NotNull] this string? value, string message, string paramName)
 		where T : ArgumentException
 		=> value!.IsWhiteSpace()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName, message)

--- a/System/src/Checks/ThrowIfZeroExtensions.cs
+++ b/System/src/Checks/ThrowIfZeroExtensions.cs
@@ -7,17 +7,17 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfZeroExtensions
 {
-	public static int ThrowIfZero(this int value)
+	public static int ThrowIfZero([NotNull] this int value)
 	{
 		return value.ThrowIfZero<ArgumentZeroException>();
 	}
 
-	public static int ThrowIfZero(this int value, string message)
+	public static int ThrowIfZero([NotNull] this int value, string message)
 	{
 		return value.ThrowIfZero<ArgumentZeroException>(message);
 	}
 
-	public static int ThrowIfZero<T>(this int value)
+	public static int ThrowIfZero<T>([NotNull] this int value)
 		where T : ArgumentException
 	{
 		return value == 0
@@ -25,7 +25,7 @@ public static class ThrowIfZeroExtensions
 			       : value;
 	}
 
-	public static int ThrowIfZero<T>(this int value, string message)
+	public static int ThrowIfZero<T>([NotNull] this int value, string message)
 		where T : ArgumentException
 	{
 		return value == 0

--- a/System/src/Wangkanai.System.csproj
+++ b/System/src/Wangkanai.System.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
-		<!--<IsTrimmable>true</IsTrimmable>-->
-		<!--<PublishAot>true</PublishAot>-->
+		<RootNamespace>Wangkanai</RootNamespace>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
The code has been refactored to use the [NotNull] annotation to enforce non-null values in various methods. This affects the ThrowIfNullExtensions, ThrowIfWhitespaceExtensions, ThrowIfEmptyStringExtensions, and several other classes. Additionally, unnecessary classes and files were deleted for cleanup.