### PR TITLE
Switch benchmark tests and update job runtime

### DIFF
--- a/System/benchmark/CheckStringBenchmark.cs
+++ b/System/benchmark/CheckStringBenchmark.cs
@@ -6,8 +6,7 @@ using Xunit;
 
 namespace Wangkanai;
 
-[SimpleJob(RuntimeMoniker.Net80)]
-[SimpleJob(RuntimeMoniker.Net70, baseline: true)]
+[SimpleJob(RuntimeMoniker.Net80, baseline: true)]
 [RPlotExporter]
 [MemoryDiagnoser]
 public class CheckStringBenchmark

--- a/System/benchmark/CheckStringBenchmark.cs
+++ b/System/benchmark/CheckStringBenchmark.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace Wangkanai;
 
+[SimpleJob(RuntimeMoniker.Net80)]
 [SimpleJob(RuntimeMoniker.Net70, baseline: true)]
 [RPlotExporter]
 [MemoryDiagnoser]

--- a/System/benchmark/Program.cs
+++ b/System/benchmark/Program.cs
@@ -5,9 +5,9 @@ global using BenchmarkDotNet.Running;
 
 global using Wangkanai;
 
-BenchmarkRunner.Run<StringSpanVsSubstringBenchmark>();
+// BenchmarkRunner.Run<StringSpanVsSubstringBenchmark>();
 // BenchmarkRunner.Run<CheckNumericBenchmark>();
-// BenchmarkRunner.Run<CheckStringBenchmark>();
+BenchmarkRunner.Run<CheckStringBenchmark>();
 // BenchmarkRunner.Run<HashBenchmark>();
 // BenchmarkRunner.Run<MathBenchmark>();
 // BenchmarkRunner.Run<ForLoopBenchmark>();


### PR DESCRIPTION
The benchmark testing routine has been modified, disabling the 'StringSpanVsSubstringBenchmark' test and enabling the 'CheckStringBenchmark' test. Additionally, a new job runtime for .NET 8.0 was added in 'CheckStringBenchmark'.