### PR TITLE
Update null check methods in NullConditionalExtensions

### DIFF
--- a/System/src/Attributes/NegativeIntegerAttribute.cs
+++ b/System/src/Attributes/NegativeIntegerAttribute.cs
@@ -3,4 +3,4 @@
 namespace Wangkanai;
 
 [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Parameter)]
-public class NegativeIntegerAttribute : Attribute { }
+public sealed class NegativeIntegerAttribute : Attribute { }

--- a/System/src/Attributes/PositiveIntegerAttribute.cs
+++ b/System/src/Attributes/PositiveIntegerAttribute.cs
@@ -3,4 +3,4 @@
 namespace Wangkanai;
 
 [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Constructor | AttributeTargets.Parameter)]
-public class PositiveIntegerAttribute : Attribute { }
+public sealed class PositiveIntegerAttribute : Attribute { }

--- a/System/src/Checks/NullConditionalExtensions.cs
+++ b/System/src/Checks/NullConditionalExtensions.cs
@@ -1,15 +1,15 @@
 // Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
+#pragma warning disable CS8777 // Parameter must have a non-null value when exiting.
+
 namespace Wangkanai;
 
 [DebuggerStepThrough]
 public static class NullConditionalExtensions
 {
-	[return: NotNull]
-	public static bool TrueIfNull<T>([NotNull] this T? value)
+	public static bool TrueIfNull<T>([NotNull] this T value)
 		=> value is null;
 
-	[return: NotNull]
-	public static bool FalseIfNull<T>([NotNull] this T? value)
+	public static bool FalseIfNull<T>([NotNull] this T value)
 		=> value is not null;
 }

--- a/System/src/Checks/ThrowIfEmptyEnumerableExtensions.cs
+++ b/System/src/Checks/ThrowIfEmptyEnumerableExtensions.cs
@@ -8,12 +8,12 @@ namespace Wangkanai;
 [DebuggerStepThrough]
 public static class ThrowIfEmptyExtensions
 {
-	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T>? value)
+	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T> value)
 		=> !value.ThrowIfNull().Any()
 			   ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value))
 			   : value;
 
-	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T>? value, string message)
+	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T> value, string message)
 		=> !value.ThrowIfNull().Any()
 			   ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value), message)
 			   : value;

--- a/System/src/Checks/ThrowIfEqualExtensions.cs
+++ b/System/src/Checks/ThrowIfEqualExtensions.cs
@@ -8,21 +8,15 @@ namespace Wangkanai;
 public static class ThrowIfEqualExtensions
 {
 	public static bool ThrowIfEqual([NotNull] this int value, int expected)
-	{
-		return value.ThrowIfEqual<ArgumentEqualException>(expected, nameof(value));
-	}
+		=> value.ThrowIfEqual<ArgumentEqualException>(expected, nameof(value));
 
 	public static bool ThrowIfEqual<T>([NotNull] this int value, int expected)
 		where T : ArgumentException
-	{
-		return value.ThrowIfEqual<T>(expected, nameof(value));
-	}
+		=> value.ThrowIfEqual<T>(expected, nameof(value));
 
 	public static bool ThrowIfEqual<T>([NotNull] this int value, int expected, string paramName)
 		where T : ArgumentException
-	{
-		return value == expected
-			       ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName)
-			       : false;
-	}
+		=> value == expected
+			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName)
+			   : false;
 }

--- a/System/src/Checks/ThrowIfNullOrEmptyExtensions.cs
+++ b/System/src/Checks/ThrowIfNullOrEmptyExtensions.cs
@@ -19,17 +19,17 @@ public static class ThrowIfNullOrEmptyExtensions
 		where T : ArgumentException
 		=> value!.IsNullOrEmpty()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value))
-			   : value!;
+			   : value;
 
 	public static string ThrowIfNullOrEmpty<T>([NotNull] this string? value, string message)
 		where T : ArgumentException
 		=> value!.IsNullOrEmpty()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(nameof(value), message)
-			   : value!;
+			   : value;
 
 	public static string ThrowIfNullOrEmpty<T>([NotNull] this string? value, string message,  string paramName)
 		where T : ArgumentException
 		=> value!.IsNullOrEmpty()
 			   ? throw ExceptionActivator.CreateArgumentInstance<T>(paramName, message)
-			   : value!;
+			   : value;
 }

--- a/System/src/Decorator.cs
+++ b/System/src/Decorator.cs
@@ -16,7 +16,7 @@ public class Decorator<TService, TImplementation> : Decorator<TService>
 	public Decorator(TImplementation instance) : base(instance) { }
 }
 
-public sealed class DisposableDecorator<TService> : Decorator<TService>, IDisposable
+public class DisposableDecorator<TService> : Decorator<TService>, IDisposable
 {
 	public DisposableDecorator(TService instance) : base(instance) { }
 

--- a/System/src/Extensions/StringExtensions.cs
+++ b/System/src/Extensions/StringExtensions.cs
@@ -6,77 +6,79 @@ using System.Text.RegularExpressions;
 
 using Wangkanai.Exceptions;
 
+#nullable disable
+
 namespace Wangkanai.Extensions;
 
 [DebuggerStepThrough]
 public static class StringExtensions
 {
-	public static bool IsEmpty(this string value)
+	public static bool IsEmpty([NotNull] this string value)
 		=> value == string.Empty;
 
-	public static bool IsNullOrEmpty(this string value)
+	public static bool IsNullOrEmpty([NotNull] this string value)
 		=> string.IsNullOrEmpty(value);
 
-	public static bool IsNotNullOrEmpty(this string value)
+	public static bool IsNotNullOrEmpty([NotNull] this string value)
 		=> !string.IsNullOrEmpty(value);
 
-	public static bool IsNullOrWhiteSpace(this string value)
+	public static bool IsNullOrWhiteSpace([NotNull] this string value)
 		=> string.IsNullOrWhiteSpace(value);
 
-	public static bool IsWhiteSpace(this string value)
+	public static bool IsWhiteSpace([NotNull] this string value)
 		=> !value.IsNullOrEmpty() && value.All(char.IsWhiteSpace);
 
-	public static bool IsNotNullOrWhiteSpace(this string value)
+	public static bool IsNotNullOrWhiteSpace([NotNull] this string value)
 		=> !value.IsNullOrWhiteSpace();
 
-	public static bool IsExist(this string value)
+	public static bool IsExist([NotNull] this string value)
 		=> !value.IsNullOrWhiteSpace();
 
-	public static bool IsUnicode(this string value)
+	public static bool IsUnicode([NotNull] this string value)
 		=> Encoding.ASCII.GetByteCount(value) != Encoding.UTF8.GetByteCount(value);
 
-	public static string EnsureLeadingSlash(this string value)
+	public static string EnsureLeadingSlash([NotNull] this string value)
 		=> value.IsNotNullOrWhiteSpace() && !value.StartsWith('/')
 			   ? "/" + value
 			   : value;
 
-	public static string EnsureTrailingSlash(this string value)
+	public static string EnsureTrailingSlash([NotNull] this string value)
 		=> value.IsNotNullOrWhiteSpace() && !value.EndsWith('/')
 			   ? value + "/"
 			   : value;
 
-	public static string RemoveLeadingSlash(this string value)
+	public static string RemoveLeadingSlash([NotNull] this string value)
 		=> value.IsNotNullOrWhiteSpace() && value.StartsWith('/')
 			   ? value.Substring(1)
 			   : value;
 
-	public static string RemoveTrailingSlash(this string value)
+	public static string RemoveTrailingSlash([NotNull] this string value)
 		=> value.IsNotNullOrWhiteSpace() && value.EndsWith('/')
 			   ? value.Substring(0, value.Length - 1)
 			   : value;
 
-	public static string EnsureStartsWith(this string value, char c)
+	public static string EnsureStartsWith([NotNull] this string value, char c)
 		=> value.EnsureStartsWith(c, StringComparison.Ordinal);
 
-	public static string EnsureStartsWith(this string value, char c, StringComparison comparison)
+	public static string EnsureStartsWith([NotNull] this string value, char c, StringComparison comparison)
 		=> value.ThrowIfNull().StartsWith(c.ToString(), comparison)
 			   ? value
 			   : c + value;
 
-	public static string EnsureStartsWith(this string value, char c, bool ignoreCase, CultureInfo culture)
+	public static string EnsureStartsWith([NotNull] this string value, char c, bool ignoreCase, CultureInfo culture)
 		=> value.ThrowIfNull().StartsWith(c.ToString(culture), ignoreCase, culture)
 			   ? value
 			   : c + value;
 
-	public static string EnsureEndsWith(this string value, char c)
+	public static string EnsureEndsWith([NotNull] this string value, char c)
 		=> value.EnsureEndsWith(c, StringComparison.Ordinal);
 
-	public static string EnsureEndsWith(this string value, char c, StringComparison comparison)
+	public static string EnsureEndsWith([NotNull] this string value, char c, StringComparison comparison)
 		=> value.ThrowIfNull().EndsWith(c.ToString(), comparison)
 			   ? value
 			   : value + c;
 
-	public static string EnsureEndsWith(this string value, char c, bool ignoreCase, CultureInfo culture)
+	public static string EnsureEndsWith([NotNull] this string value, char c, bool ignoreCase, CultureInfo culture)
 		=> value.ThrowIfNull().EndsWith(c.ToString(culture), ignoreCase, culture)
 			   ? value
 			   : value + c;
@@ -90,7 +92,7 @@ public static class StringExtensions
 		return match.Success ? match : Match.Empty;
 	}
 
-	public static string Left(this string value, int length)
+	public static string Left([NotNull] this string value, int length)
 	{
 		value.ThrowIfNull();
 		value.Length.ThrowIfLessThan(length, nameof(length));
@@ -98,7 +100,7 @@ public static class StringExtensions
 		return value.Substring(0, length);
 	}
 
-	public static string Right(this string value, int length)
+	public static string Right([NotNull] this string value, int length)
 	{
 		value.ThrowIfNull();
 		value.Length.ThrowIfLessThan(length);
@@ -106,19 +108,19 @@ public static class StringExtensions
 		return value.Substring(value.Length - length, length);
 	}
 
-	public static string RemoveAll(this string source, params string[] strings)
+	public static string RemoveAll([NotNull] this string source, params string[] strings)
 		=> strings.ThrowIfNull().Aggregate(source.ThrowIfNull(), ReplaceOrdinal);
 
-	private static string ReplaceOrdinal(string current, string target)
+	private static string ReplaceOrdinal([NotNull] string current, string target)
 		=> current.ThrowIfNull().Replace(target.ThrowIfNull(), "", StringComparison.Ordinal);
 
-	public static string RemovePreFixes(this string value, params string[] prefixes)
+	public static string RemovePreFixes([NotNull] this string value, params string[] prefixes)
 		=> value.ThrowIfNull().RemovePreFixes(StringComparison.OrdinalIgnoreCase, prefixes);
 
-	public static string RemovePreFixes(this string value, StringComparison comparison, params string[] prefixes)
+	public static string RemovePreFixes([NotNull] this string value, StringComparison comparison, params string[] prefixes)
 		=> value.ThrowIfNull().RemovePreFixes(true, CultureInfo.InvariantCulture, prefixes);
 
-	public static string RemovePreFixes(this string value, bool ignoreCase, CultureInfo culture, params string[] prefixes)
+	public static string RemovePreFixes([NotNull] this string value, bool ignoreCase, CultureInfo culture, params string[] prefixes)
 	{
 		value.ThrowIfNull();
 
@@ -134,13 +136,13 @@ public static class StringExtensions
 		return value;
 	}
 
-	public static string RemovePostFixes(this string value, params string[] postfixes)
+	public static string RemovePostFixes([NotNull] this string value, params string[] postfixes)
 		=> value.RemovePostFixes(StringComparison.OrdinalIgnoreCase, postfixes);
 
-	public static string RemovePostFixes(this string value, StringComparison comparison, params string[] postfixes)
+	public static string RemovePostFixes([NotNull] this string value, StringComparison comparison, params string[] postfixes)
 		=> value.RemovePostFixes(true, CultureInfo.InvariantCulture, postfixes);
 
-	public static string RemovePostFixes(this string value, bool ignoreCase, CultureInfo culture, params string[] postfixes)
+	public static string RemovePostFixes([NotNull] this string value, bool ignoreCase, CultureInfo culture, params string[] postfixes)
 	{
 		value.ThrowIfNull();
 
@@ -156,13 +158,13 @@ public static class StringExtensions
 		return value;
 	}
 
-	public static IEnumerable<string> Split(this string value, int size)
+	public static IEnumerable<string> Split([NotNull] this string value, int size)
 	{
 		value.ThrowIfNull().ThrowIfEmpty().ThrowIfNullOrWhitespace<ArgumentEmptyException>();
 		return Enumerable.Range(0, value.Length / size).Select(index => value.Substring(index * size, size));
 	}
 
-	public static T ToEnum<T>(this string value, bool ignoreCase = true)
+	public static T ToEnum<T>([NotNull] this string value, bool ignoreCase = true)
 		where T : struct
 	{
 		value.ThrowIfNull();
@@ -172,7 +174,7 @@ public static class StringExtensions
 		return (T)Enum.Parse(typeof(T), value, ignoreCase);
 	}
 
-	public static string Truncate(this string value, int maxLength)
+	public static string Truncate([NotNull] this string value, int maxLength)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -182,7 +184,7 @@ public static class StringExtensions
 		return value.Left(maxLength);
 	}
 
-	public static string TruncateWithPostfix(this string value, int maxLength, string postfix = "...")
+	public static string TruncateWithPostfix([NotNull] this string value, int maxLength, string postfix = "...")
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -194,7 +196,7 @@ public static class StringExtensions
 			       : value.Left(maxLength - postfix.Length) + postfix;
 	}
 
-	public static string SubstringSafe(this string value, int start = 0)
+	public static string SubstringSafe([NotNull] this string value, int start = 0)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -203,7 +205,7 @@ public static class StringExtensions
 		return value.SubstringSafe(start, value.Length);
 	}
 
-	public static string SubstringSafe(this string value, int start, int length)
+	public static string SubstringSafe([NotNull] this string value, int start, int length)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -215,7 +217,7 @@ public static class StringExtensions
 			       : value[start..];
 	}
 
-	public static string ToTitleCase(this string value)
+	public static string ToTitleCase([NotNull] this string value)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -224,7 +226,7 @@ public static class StringExtensions
 		return string.Concat(value.AsSpan(0, 1).ToString().ToUpper(), value.AsSpan(1));
 	}
 
-	public static string EscapeSearch(this string value)
+	public static string EscapeSearch([NotNull] this string value)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -246,7 +248,7 @@ public static class StringExtensions
 		return result.ToString().Trim();
 	}
 
-	public static string EscapeSelector(this string value)
+	public static string EscapeSelector([NotNull] this string value)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -256,7 +258,7 @@ public static class StringExtensions
 		return Regex.Replace(value, pattern, replacement, RegexOptions.Compiled, Constants.RegexTimeout);
 	}
 
-	public static string RemoveAccent(this string value)
+	public static string RemoveAccent([NotNull] this string value)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -267,7 +269,7 @@ public static class StringExtensions
 		return Encoding.ASCII.GetString(bytes);
 	}
 
-	public static string GenerateSlug(this string value)
+	public static string GenerateSlug([NotNull] this string value)
 	{
 		value.ThrowIfNull();
 		value.ThrowIfEmpty();
@@ -286,10 +288,10 @@ public static class StringExtensions
 		return str;
 	}
 
-	public static bool EqualsInvariant(this string str1, string str2)
+	public static bool EqualsInvariant([NotNull] this string str1, string str2)
 		=> string.Equals(str1, str2, StringComparison.OrdinalIgnoreCase);
 
-	public static string SeparateToSpace(this IEnumerable<string> list)
+	public static string SeparateToSpace([NotNull] this IEnumerable<string> list)
 	{
 		list.ThrowIfNull();
 		list.ThrowIfEmpty();
@@ -298,7 +300,7 @@ public static class StringExtensions
 			       : string.Join(' ', list);
 	}
 
-	public static IEnumerable<string> SeparateFromSpace(this string value)
+	public static IEnumerable<string> SeparateFromSpace([NotNull] this string value)
 		=> value.ThrowIfNull()
 		        .ThrowIfEmpty()
 		        .Trim()

--- a/System/src/Reflection/PropertyCopy.cs
+++ b/System/src/Reflection/PropertyCopy.cs
@@ -2,6 +2,8 @@
 
 using System.Linq.Expressions;
 
+using ArgumentException = System.ArgumentException;
+
 namespace Wangkanai.Reflection;
 
 public static class PropertyCopy<TTarget> where TTarget : class, new()
@@ -12,8 +14,8 @@ public static class PropertyCopy<TTarget> where TTarget : class, new()
 
 	private static class PropertyCopier<TSource> where TSource : class
 	{
-		private static Exception              _intialization;
 		private static Func<TSource, TTarget> _copier;
+		private static Exception              _intialization;
 
 		static PropertyCopier()
 		{
@@ -31,7 +33,7 @@ public static class PropertyCopy<TTarget> where TTarget : class, new()
 
 		internal static TTarget Copy(TSource source)
 		{
-			if (_intialization != null)
+			if (_intialization is not null)
 				throw _intialization;
 
 			source.ThrowIfNull();
@@ -57,10 +59,12 @@ public static class PropertyCopy<TTarget> where TTarget : class, new()
 					throw new ArgumentException($"Property {sourceProperty.Name} is not writable in {typeof(TTarget).FullName}");
 				if (!targetProperty.PropertyType.IsAssignableFrom(sourceProperty.PropertyType))
 					throw new ArgumentException($"Property {sourceProperty.Name} is not assignable type in {targetProperty.PropertyType.FullName}");
+
 				bindings.Add(Expression.Bind(targetProperty, Expression.Property(sourceParameter, sourceProperty)));
 			}
 
 			var initializer = Expression.MemberInit(Expression.New(typeof(TTarget)), bindings);
+
 			return Expression.Lambda<Func<TSource, TTarget>>(initializer, sourceParameter).Compile();
 		}
 	}

--- a/System/tests/Checks/CheckBooleanTests.cs
+++ b/System/tests/Checks/CheckBooleanTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace Wangkanai.Checks;
 

--- a/System/tests/Checks/CheckCompareTests.cs
+++ b/System/tests/Checks/CheckCompareTests.cs
@@ -18,7 +18,7 @@ public class CheckCompareTests
 	[Fact]
 	public void ThrowIfEqualExtension()
 	{
-		var test = "test";
+		const string test = "test";
 		Assert.False(test.Length.ThrowIfEqual(8));
 		Assert.Throws<ArgumentEqualException>(() => test.Length.ThrowIfEqual(4));
 		Assert.Throws<ArgumentEqualException>(() => test.Length.ThrowIfEqual<ArgumentEqualException>(4));
@@ -35,7 +35,7 @@ public class CheckCompareTests
 	[Fact]
 	public void ThrowIfNotEqualExtension()
 	{
-		var test = "test";
+		const string test = "test";
 		Assert.True(test.Length.ThrowIfNotEqual(4));
 		Assert.Throws<ArgumentNotEqualException>(() => test.Length.ThrowIfNotEqual(8));
 		Assert.Throws<ArgumentNotEqualException>(() => test.Length.ThrowIfNotEqual<ArgumentNotEqualException>(8));
@@ -83,7 +83,7 @@ public class CheckCompareTests
 	[Fact]
 	public void ThrowIfZeroPositive()
 	{
-		var positive = 1;
+		const int positive = 1;
 		Assert.Equal(1, positive.ThrowIfZero());
 		Assert.Equal(1, positive.ThrowIfZero<ArgumentZeroException>());
 		Assert.Equal(1, positive.ThrowIfZero<ArgumentZeroException>(nameof(ThrowIfZeroPositive)));
@@ -92,7 +92,7 @@ public class CheckCompareTests
 	[Fact]
 	public void ThrowIfZeroNegative()
 	{
-		var negative = -1;
+		const int negative = -1;
 		Assert.Equal(-1, negative.ThrowIfZero());
 		Assert.Equal(-1, negative.ThrowIfZero<ArgumentZeroException>());
 		Assert.Equal(-1, negative.ThrowIfZero<ArgumentZeroException>(nameof(ThrowIfZeroNegative)));
@@ -101,7 +101,7 @@ public class CheckCompareTests
 	[Fact]
 	public void ThrowIfZeroFail()
 	{
-		var zero = 0;
+		const int zero = 0;
 		Assert.Throws<ArgumentZeroException>(() => zero.ThrowIfZero());
 		Assert.Throws<ArgumentZeroException>(() => zero.ThrowIfZero<ArgumentZeroException>());
 		Assert.Throws<ArgumentZeroException>(() => zero.ThrowIfZero<ArgumentZeroException>(nameof(ThrowIfZeroFail)));

--- a/System/tests/Checks/CheckEmptyListTests.cs
+++ b/System/tests/Checks/CheckEmptyListTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-#nullable enable
+#nullable disable
 
 using Wangkanai.Exceptions;
 
@@ -10,9 +10,9 @@ namespace Wangkanai.Checks;
 
 public class CheckEmptyListTests
 {
-	List<int>? _null  = null!;
-	List<int>? _empty = new();
-	List<int>? _list  = new() { 1, 2, 3 };
+	List<int> _null  = null!;
+	List<int> _empty = new();
+	List<int> _list  = new() { 1, 2, 3 };
 
 	[Fact]
 	public void BasicNull()

--- a/System/tests/Checks/CheckEmptyStringTests.cs
+++ b/System/tests/Checks/CheckEmptyStringTests.cs
@@ -8,8 +8,8 @@ namespace Wangkanai.Checks;
 
 public class CheckEmptyStringTests
 {
-	string _null  = null!;
-	string _empty = string.Empty;
+	private readonly string _null  = null!;
+	private readonly string _empty = string.Empty;
 
 	[Fact]
 	public void BasicNull()

--- a/System/tests/Checks/CheckIndexRangeTests.cs
+++ b/System/tests/Checks/CheckIndexRangeTests.cs
@@ -17,7 +17,7 @@ public class CheckIndexRangeTests
 	[Fact]
 	public void IndexIsOutOfRange()
 	{
-		// The index must be 1 less then the upper bound.
+		// The index must be 1 less than the upper bound.
 		Assert.Throws<ArgumentOutOfRangeException>(() => 10.ThrowIfOutOfRange(0, 10));
 		Assert.Throws<ArgumentOutOfRangeException>(() => 10.ThrowIfOutOfRange(0, 9));
 		Assert.Throws<ArgumentOutOfRangeException>(() => 10.ThrowIfOutOfRange(11, 15));

--- a/System/tests/Checks/CheckNullTests.cs
+++ b/System/tests/Checks/CheckNullTests.cs
@@ -2,6 +2,8 @@
 
 using Xunit;
 
+// ReSharper disable InconsistentNaming
+
 namespace Wangkanai.Checks;
 
 public class CheckNullTests

--- a/System/tests/Checks/CheckNumericTests.cs
+++ b/System/tests/Checks/CheckNumericTests.cs
@@ -37,22 +37,22 @@ public class CheckNumericTests
 	[Fact]
 	public void ThrowIfNegative()
 	{
-		int postitive = 1;
-		int negative  = -1;
-		int zero      = 0;
+		const int positive = 1;
+		const int negative = -1;
+		const int zero     = 0;
 
 		Assert.Throws<ArgumentNegativeException>(() => negative.ThrowIfNegative());
 		Assert.Throws<ArgumentNegativeException>(() => negative.ThrowIfNegative("message"));
 		Assert.Equal(0, zero.ThrowIfNegative());
-		Assert.Equal(1, postitive.ThrowIfNegative());
+		Assert.Equal(1, positive.ThrowIfNegative());
 	}
 
 	[Fact]
 	public void ThrowIfZero()
 	{
-		int posittive = 1;
-		int negative  = -1;
-		int zero      = 0;
+		const int posittive = 1;
+		const int negative  = -1;
+		const int zero      = 0;
 
 		Assert.Throws<ArgumentZeroException>(() => zero.ThrowIfZero());
 		Assert.Throws<ArgumentZeroException>(() => zero.ThrowIfZero("message"));
@@ -63,12 +63,12 @@ public class CheckNumericTests
 	[Fact]
 	public void ThrowIfPositive()
 	{
-		int posittive = 1;
-		int negative  = -1;
-		int zero      = 0;
+		const int positive = 1;
+		const int negative = -1;
+		const int zero     = 0;
 
-		Assert.Throws<ArgumentPositiveException>(() => posittive.ThrowIfPositive());
-		Assert.Throws<ArgumentPositiveException>(() => posittive.ThrowIfPositive("message"));
+		Assert.Throws<ArgumentPositiveException>(() => positive.ThrowIfPositive());
+		Assert.Throws<ArgumentPositiveException>(() => positive.ThrowIfPositive("message"));
 		Assert.Equal(0, zero.ThrowIfPositive());
 		Assert.Equal(-1, negative.ThrowIfPositive());
 	}

--- a/System/tests/Checks/CheckStringTests.cs
+++ b/System/tests/Checks/CheckStringTests.cs
@@ -3,6 +3,7 @@
 using Wangkanai.Exceptions;
 
 using Xunit;
+// ReSharper disable InconsistentNaming
 
 namespace Wangkanai.Checks;
 

--- a/System/tests/Checks/CreateExceptionInstanceTests.cs
+++ b/System/tests/Checks/CreateExceptionInstanceTests.cs
@@ -9,8 +9,8 @@ public class CreateExceptionInstanceTests
 	[Fact]
 	public void CreateExceptionInstance()
 	{
-		var value     = 1;
-		var exception = ExceptionActivator.CreateGenericInstance<ArgumentNullException>(nameof(value));
+		const int value     = 1;
+		var       exception = ExceptionActivator.CreateGenericInstance<ArgumentNullException>(nameof(value));
 		Assert.Equal(1, value);
 		Assert.Equal(typeof(ArgumentNullException), exception.GetType());
 	}
@@ -18,8 +18,8 @@ public class CreateExceptionInstanceTests
 	[Fact]
 	public void CreateExceptionInstanceWithMessage()
 	{
-		var value     = 1;
-		var exception = ExceptionActivator.CreateGenericInstance<ArgumentNullException>(nameof(value), "message");
+		const int value     = 1;
+		var       exception = ExceptionActivator.CreateGenericInstance<ArgumentNullException>(nameof(value), "message");
 		Assert.Equal(1, value);
 		Assert.Equal(typeof(ArgumentNullException), exception.GetType());
 		Assert.Equal("message (Parameter 'value')", exception.Message);

--- a/Webserver/src/DependencyInjection/DecoratorServiceExtensions.cs
+++ b/Webserver/src/DependencyInjection/DecoratorServiceExtensions.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using System.Linq;
 
 namespace Microsoft.Extensions.DependencyInjection;
 


### PR DESCRIPTION
The null check methods TrueIfNull and FalseIfNull in the NullConditionalExtensions class have been updated. The input parameters no longer accept nullable types. Also, a warning for non-null parameters when exiting has been added.