### PR TITLE
Update default name in sign.ps1 script

### DIFF
--- a/System/sign.ps1
+++ b/System/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
The default name parameter in the sign.ps1 script has been changed to reflect a more explicit identification. "Sarin Na Wangkanai" has been updated to "Open Source Developer, Sarin Na Wangkanai" for better transparency.