### PR TITLE
Refactor PlatformService and update tests

### DIFF
--- a/Detection/sign.ps1
+++ b/Detection/sign.ps1
@@ -15,7 +15,7 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/Detection/src/Services/PlatformService.cs
+++ b/Detection/src/Services/PlatformService.cs
@@ -56,17 +56,17 @@ public sealed class PlatformService : IPlatformService
 		var agent    = _userAgentService.UserAgent.ToLower();
 		var platform = Name;
 		return platform switch
-		       {
-			       Platform.Unknown => new Version(),
-			       Platform.Others  => new Version(),
-			       Platform.Windows => ParseOsVersion(agent, "windowsnt"),
-			       Platform.Android => ParseOsVersion(agent, "android"),
-			       Platform.Mac     => ParseOsVersion(agent, "intelmacosx"),
-			       Platform.iOS     => ParseOsVersion(agent, "cpuiphoneos"),
-			       Platform.iPadOS  => ParseOsVersion(agent, "cpuos"),
-			       Platform.Linux   => ParseOsVersion(agent, "rv:"),
-			       _                => new Version()
-		       };
+		{
+			Platform.Unknown => new Version(),
+			Platform.Others  => new Version(),
+			Platform.Windows => ParseOsVersion(agent, "windowsnt"),
+			Platform.Android => ParseOsVersion(agent, "android"),
+			Platform.Mac     => ParseOsVersion(agent, "intelmacosx"),
+			Platform.iOS     => ParseOsVersion(agent, "cpuiphoneos"),
+			Platform.iPadOS  => ParseOsVersion(agent, "cpuos"),
+			Platform.Linux   => ParseOsVersion(agent, "rv:"),
+			_                => new Version()
+		};
 	}
 
 	private Processor GetProcessor()
@@ -137,26 +137,19 @@ public sealed class PlatformService : IPlatformService
 	}
 
 	private static string ReplaceUnderscore(string value)
-	{
-		return value.Replace("_", ".");
-	}
+		=> value.Replace("_", ".");
 
 	private static string AgentSourceParse(string agent, string prefix)
-	{
-		return AgentSourceStart(agent, prefix) ?? string.Empty;
-	}
+		=> AgentSourceStart(agent, prefix) ?? string.Empty;
 
 	private static string AgentSourceStart(string agent, string prefix)
-	{
-		return _osStartRegex.RegexMatch(agent)
-		                    .Captures
-		                    .FirstOrDefault()
-		                    ?
-		                    .Value
-		                    .RemoveAll(" ", "(", ")")
-		                    .Split(';')
-		                    .FirstOrDefault(x => x.StartsWith(prefix, StringComparison.Ordinal));
-	}
+		=> _osStartRegex.RegexMatch(agent)
+		                .Captures
+		                .FirstOrDefault()?
+		                .Value
+		                .RemoveAll(" ", "(", ")")
+		                .Split(';')
+		                .FirstOrDefault(x => x.StartsWith(prefix, StringComparison.Ordinal));
 
 
 	private static readonly string[]  X86DeviceList     = { "i86", "i686", Processor.x86.ToStringInvariant() };

--- a/Detection/tests/Services/PlatformServiceTests.cs
+++ b/Detection/tests/Services/PlatformServiceTests.cs
@@ -58,6 +58,17 @@ public class PlatformServiceTests
 	}
 
 	[Theory]
+	[InlineData("10.0", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")]
+	[InlineData("10.0", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")]
+	public void WindowsVersion(string version, string agent)
+	{
+		var os       = Platform.Windows;
+		var resolver = MockService.PlatformService(agent);
+		Assert.Equal(os, resolver.Name);
+		Assert.Equal(new Version(version), resolver.Version);
+	}
+
+	[Theory]
 	[InlineData("Mozilla/5.0 (Android 4.4; Mobile; rv:41.0) Gecko/41.0 Firefox/41.0")]
 	[InlineData("Mozilla/5.0 (Linux; Android 7.0; SM-T585 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36")]
 	[InlineData("Mozilla/5.0 (Linux; Android 4.4.2); Nexus 5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.117 Mobile Safari/537.36 OPR/20.0.1396.72047")]

--- a/System/Directory.Build.props
+++ b/System/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>5.0.0</VersionPrefix>
+		<VersionPrefix>4.1.0</VersionPrefix>
 		<Title>Wangkanai System</Title>
 		<PackageTags>aspnetcore;sytem;runtime;</PackageTags>
 		<Description>A powerful library of extensions that unlocks the full potential of your .NET runtime. Simplify your coding process, enhance application structure, and reduce boilerplate code. Join us in pushing the boundaries of .NET, writing clean and efficient code that is robust and maintainable. Elevate your development journey with Wangkanai System!</Description>
@@ -20,3 +20,4 @@
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 </Project>
+

--- a/System/Directory.Build.props
+++ b/System/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.1.0</VersionPrefix>
+		<VersionPrefix>5.0.0</VersionPrefix>
 		<Title>Wangkanai System</Title>
 		<PackageTags>aspnetcore;sytem;runtime;</PackageTags>
 		<Description>A powerful library of extensions that unlocks the full potential of your .NET runtime. Simplify your coding process, enhance application structure, and reduce boilerplate code. Join us in pushing the boundaries of .NET, writing clean and efficient code that is robust and maintainable. Elevate your development journey with Wangkanai System!</Description>


### PR DESCRIPTION
Simplified method implementation in PlatformService.cs by converting some methods into expression-bodied members. This reduces unnecessary boilerplate and enhances readability. Additionally, a new test case for Windows version detection was added to the PlatformServiceTests.cs to ensure accuracy and reliability of our service.

Ref: #955