### PR TITLE
Update developer's name and correct casing in scripts

### DIFF
--- a/Analytics/sign.ps1
+++ b/Analytics/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Blazor/sign.ps1
+++ b/Blazor/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Cryptography/sign.ps1
+++ b/Cryptography/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue
@@ -15,7 +15,7 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 

--- a/Detection/Directory.Build.props
+++ b/Detection/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>8.13.0</VersionPrefix>
+		<VersionPrefix>8.14.0</VersionPrefix>
 		<Title>Wangkanai Detection</Title>
 		<Description>Introducing `Detection` – your gateway to understanding your users' interactions with your ASP.NET Core application. With over 10 million downloads, `Detection` offers invaluable insights into your client's device, browser, engine, and platform, even identifying crawlers. Tailor your application to your users' needs, enhance the user experience, and optimize for SEO. Discover the power of `Detection` and let's create seamless, personalized experiences for all users.</Description>
 		<PackageTags>aspnetcore;detection;</PackageTags>

--- a/Domain/sign.ps1
+++ b/Domain/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue
@@ -15,7 +15,7 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg

--- a/EntityFramework/Directory.Build.props
+++ b/EntityFramework/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.1.0</VersionPrefix>
+		<VersionPrefix>3.2.0</VersionPrefix>
 		<Title>Wangkanai EntityFramework</Title>
 		<PackageTags>aspnetcore;entityframework;efcore;</PackageTags>
 		<Description>Elevate your Entity Framework experience with `EntityFramework`. A productivity powerhouse, this library comes packed with extra features and helpers to simplify your development workflow. From managing complex relationships to executing efficient queries, `EntityFramework` is your ultimate tool for data handling in ASP.NET Core.</Description>

--- a/EntityFramework/sign.ps1
+++ b/EntityFramework/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue
@@ -15,7 +15,7 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 

--- a/Extensions/sign.ps1
+++ b/Extensions/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Federation/sign.ps1
+++ b/Federation/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Hosting/sign.ps1
+++ b/Hosting/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue
@@ -15,7 +15,7 @@ dotnet --version
 dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
-Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*release*" } | foreach {
+Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
 

--- a/Identity/sign.ps1
+++ b/Identity/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Markdown/sign.ps1
+++ b/Markdown/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Mvc/sign.ps1
+++ b/Mvc/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Responsive/sign.ps1
+++ b/Responsive/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Security/sign.ps1
+++ b/Security/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Solver/sign.ps1
+++ b/Solver/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Tabler/sign.ps1
+++ b/Tabler/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Testing/sign.ps1
+++ b/Testing/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Tools/sign.ps1
+++ b/Tools/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Validation/sign.ps1
+++ b/Validation/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/Webmaster/sign.ps1
+++ b/Webmaster/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue
@@ -12,13 +12,13 @@ new-item -Path artifacts -ItemType Directory -Force | out-null
 new-item -Path signed    -ItemType Directory -Force | out-null
 
 dotnet --version
-dotnet clean   .\src\ -c Release
+dotnet clean   .\src\ -c Release -tl
 dotnet restore .\src\
 dotnet build   .\src\ -c Release -tl
 Get-ChildItem  .\src\ -Recurse Wangkanai.*.dll | where { $_.Directory -like "*Release*" } | foreach {
     signtool sign /fd SHA256 /t http://timestamp.digicert.com /n $name $_.FullName
 }
-dotnet pack .\src\ -c Release -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
+dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageFormat=snupkg
 
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed

--- a/Webserver/sign.ps1
+++ b/Webserver/sign.ps1
@@ -2,7 +2,7 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$dryrun=$false,
     [Parameter(mandatory=$false)]
-    [string]$name="Sarin Na Wangkanai"
+    [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
 
 remove-item -path .\signed\*.*    -Force -ErrorAction SilentlyContinue

--- a/sign.ps1
+++ b/sign.ps1
@@ -6,20 +6,20 @@ param(
 )
 
 $dirs=[ordered]@{
-#   1="System";
-#   2="Validation";
-#   3="Extensions";
-#   4="Testing";
-#   5="Cryptography";
-#   6="Hosting";
-#   7="Tools";
+#    1="System";
+#    2="Validation";
+#    3="Extensions";
+#    4="Testing";
+#    5="Cryptography";
+#    6="Hosting";
+#    7="Tools";
 #    8="Domain";
 #    9="Mvc";
 #    10="Webserver";
 #    11="Webmaster";
-    12="Detection";
+#    12="Detection";
 #    13="Responsive";
-    14="EntityFramework";
+#    14="EntityFramework";
 #    15="Identity";
 #    16="Security";
 #    17="Federation";


### PR DESCRIPTION
Multiple scripts have been updated to reflect the developer's full professional title. Furthermore, the casing of the 'Release' directory as used in the build and packing process has been corrected in several places to properly match the directory names.