### PR TITLE
Add DateTimeExtensions tests and update Truncate method

### DIFF
--- a/System/src/Extensions/DateTimeExtensions.cs
+++ b/System/src/Extensions/DateTimeExtensions.cs
@@ -5,7 +5,7 @@ namespace Wangkanai.Extensions;
 public static class DateTimeExtensions
 {
 	public static DateTime Truncate(this DateTime dateTime, TimeSpan timeSpan)
-		=> timeSpan == TimeSpan.Zero
-			   ? dateTime // Or could throw an ArgumentException
-			   : dateTime.AddTicks(-(dateTime.Ticks % timeSpan.Ticks));
+		=> timeSpan != TimeSpan.Zero
+			   ? dateTime.AddTicks(-(dateTime.Ticks % timeSpan.Ticks)) // Or could throw an ArgumentException
+			   : dateTime;
 }

--- a/System/tests/Extensions/DateTimeExtensionsTests.cs
+++ b/System/tests/Extensions/DateTimeExtensionsTests.cs
@@ -1,0 +1,53 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+using Xunit;
+
+namespace Wangkanai.Extensions;
+
+public class DateTimeExtensionsTests
+{
+	[Fact]
+	public void Truncate()
+	{
+		// Arrange
+		var dateTime = new DateTime(2022, 1, 1, 12, 30, 30);
+		var timeSpan = new TimeSpan(0, 0, 0, 0, 500);
+
+		// Act
+		var expected = new DateTime(2022, 1, 1, 12, 30, 30);
+		var actual   = dateTime.Truncate(timeSpan);
+
+		// Assert
+		Assert.Equal(expected, actual);
+	}
+
+	[Fact]
+	public void Truncate_Zero()
+	{
+		// Arrange
+		var dateTime = new DateTime(2022, 1, 1, 12, 30, 30);
+		var timeSpan = TimeSpan.Zero;
+
+		// Act
+		var expected = new DateTime(2022, 1, 1, 12, 30, 30);
+		var actual   = dateTime.Truncate(timeSpan);
+
+		// Assert
+		Assert.Equal(expected, actual);
+	}
+
+	[Fact]
+	public void Truncate_Negative()
+	{
+		// Arrange
+		var dateTime = new DateTime(2022, 1, 1, 12, 45, 15);
+		var timeSpan = new TimeSpan(-1, 0, 0, 0, 0);
+
+		// Act
+		var expected = new DateTime(2022, 1, 1, 0, 0, 0);
+		var actual   = dateTime.Truncate(timeSpan);
+
+		// Assert
+		Assert.Equal(expected, actual);
+	}
+}


### PR DESCRIPTION
The new file DateTimeExtensionsTests.cs has been added to test the Truncate method in DateTimeExtensions. It includes three different scenarios: normal use, zero timespan, and negative timespan. Additionally, the Truncate method has been adjusted to handle TimeSpan.Zero more efficiently by returning the original datetime parameter.