### PR TITLE
Refactor GetValueSafe method in DictionaryExtension

### DIFF
--- a/System/src/Extensions/DictionaryExtension.cs
+++ b/System/src/Extensions/DictionaryExtension.cs
@@ -22,9 +22,9 @@ public static class DictionaryExtension
 	/// </summary>
 	[DebuggerStepThrough]
 	public static TValue GetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
-		=> key != null && dictionary.TryGetValue(key, out var value)
-			   ? value
-			   : defaultValue;
+		=> key == null || !dictionary.TryGetValue(key, out var value)
+			   ? defaultValue
+			   : value;
 
 	/// <summary>
 	/// Doesn't throw an exception when the key is null

--- a/System/src/Extensions/DictionaryExtensions.cs
+++ b/System/src/Extensions/DictionaryExtensions.cs
@@ -2,7 +2,7 @@
 
 namespace Wangkanai.Extensions;
 
-public static class DictionaryExtension
+public static class DictionaryExtensions
 {
 	[DebuggerStepThrough]
 	public static TValue GetValueOrThrow<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, string exceptionMessage)

--- a/System/tests/Attributes/DeprecateAttributeTests.cs
+++ b/System/tests/Attributes/DeprecateAttributeTests.cs
@@ -4,8 +4,6 @@ using System.Reflection;
 
 using Wangkanai.Attributes;
 
-using Xunit;
-
 namespace Wangkanai;
 
 public class DeprecateAttributeTests

--- a/System/tests/Checks/CheckBooleanTests.cs
+++ b/System/tests/Checks/CheckBooleanTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
+
 // ReSharper disable InconsistentNaming
 
 namespace Wangkanai.Checks;

--- a/System/tests/Checks/CheckCompareTests.cs
+++ b/System/tests/Checks/CheckCompareTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Checks;
 
 public class CheckCompareTests

--- a/System/tests/Checks/CheckEmptyListTests.cs
+++ b/System/tests/Checks/CheckEmptyListTests.cs
@@ -4,8 +4,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Checks;
 
 public class CheckEmptyListTests

--- a/System/tests/Checks/CheckEmptyStringTests.cs
+++ b/System/tests/Checks/CheckEmptyStringTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Checks;
 
 public class CheckEmptyStringTests

--- a/System/tests/Checks/CheckIndexRangeTests.cs
+++ b/System/tests/Checks/CheckIndexRangeTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Checks;
 
 public class CheckIndexRangeTests

--- a/System/tests/Checks/CheckNullTests.cs
+++ b/System/tests/Checks/CheckNullTests.cs
@@ -1,6 +1,6 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
+
 
 // ReSharper disable InconsistentNaming
 

--- a/System/tests/Checks/CheckNumericTests.cs
+++ b/System/tests/Checks/CheckNumericTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Checks;
 
 public class CheckNumericTests

--- a/System/tests/Checks/CheckStringTests.cs
+++ b/System/tests/Checks/CheckStringTests.cs
@@ -2,7 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
 // ReSharper disable InconsistentNaming
 
 namespace Wangkanai.Checks;

--- a/System/tests/Checks/CreateExceptionInstanceTests.cs
+++ b/System/tests/Checks/CreateExceptionInstanceTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Checks;
 
 public class CreateExceptionInstanceTests

--- a/System/tests/Collections/ComparisonComparerTests.cs
+++ b/System/tests/Collections/ComparisonComparerTests.cs
@@ -2,8 +2,6 @@
 
 using Moq;
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class ComparisonComparerTests

--- a/System/tests/Collections/DictionaryByTypeTests.cs
+++ b/System/tests/Collections/DictionaryByTypeTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class DictionaryByTypeTests

--- a/System/tests/Collections/ProjectionComparerTests.cs
+++ b/System/tests/Collections/ProjectionComparerTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class ProjectionComparerTest

--- a/System/tests/Collections/ProjectionEqualityComparerTests.cs
+++ b/System/tests/Collections/ProjectionEqualityComparerTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class ProjectionEqualityComparerTests

--- a/System/tests/Collections/RandomAccessQueueTests.cs
+++ b/System/tests/Collections/RandomAccessQueueTests.cs
@@ -2,8 +2,6 @@
 
 using System.Collections;
 
-using Xunit;
-
 using StringQueue = Wangkanai.Collections.RandomAccessQueue<string>;
 
 namespace Wangkanai.Collections;

--- a/System/tests/Collections/RangeIteratorTests.cs
+++ b/System/tests/Collections/RangeIteratorTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class RangeIteratorTests

--- a/System/tests/Collections/RangeTests.cs
+++ b/System/tests/Collections/RangeTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class RangeTests

--- a/System/tests/Collections/ReverseComparerTests.cs
+++ b/System/tests/Collections/ReverseComparerTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Collections;
 
 public class ReverseComparerTests

--- a/System/tests/DecoratorTests.cs
+++ b/System/tests/DecoratorTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai;
 
 public class DecoratorTests

--- a/System/tests/Domain/AbstractTypeFactoryTests.cs
+++ b/System/tests/Domain/AbstractTypeFactoryTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 #nullable enable
 
 namespace Wangkanai.Domain;

--- a/System/tests/Domain/GenericTypeInfoTests.cs
+++ b/System/tests/Domain/GenericTypeInfoTests.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
 #nullable enable
-using Xunit;
-
 namespace Wangkanai.Domain;
 
 public class GenericTypeInfoTests

--- a/System/tests/Extensions/AssemblyExtensionsTests.cs
+++ b/System/tests/Extensions/AssemblyExtensionsTests.cs
@@ -4,8 +4,6 @@ using System.Reflection;
 
 using FluentAssertions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class AssemblyExtensionsTests

--- a/System/tests/Extensions/AttributeExtensionsTests.cs
+++ b/System/tests/Extensions/AttributeExtensionsTests.cs
@@ -1,7 +1,5 @@
 // Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class AttributeExtensionsTests

--- a/System/tests/Extensions/CollectionExtensionsTests.cs
+++ b/System/tests/Extensions/CollectionExtensionsTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class CollectionExtensionsTests

--- a/System/tests/Extensions/ComparerExtensionsTests.cs
+++ b/System/tests/Extensions/ComparerExtensionsTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Collections;
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class ComparerExtensionsTests

--- a/System/tests/Extensions/DateTimeFactory/DateTimeFactoryExtensionsTests.cs
+++ b/System/tests/Extensions/DateTimeFactory/DateTimeFactoryExtensionsTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions.DateTimeFactory;
 
 public class DateTimeFactoryExtensionsTests

--- a/System/tests/Extensions/DateTimeFactory/TimeSpanFactoryExtensionsTests.cs
+++ b/System/tests/Extensions/DateTimeFactory/TimeSpanFactoryExtensionsTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions.DateTimeFactory;
 
 public class TimeSpanFactoryExtensionsTests

--- a/System/tests/Extensions/DictionaryExtensionsTests.cs
+++ b/System/tests/Extensions/DictionaryExtensionsTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Extensions.Tests;
+
+public class DictionaryExtensionsTests
+{
+	[Fact]
+	public void GetValueOrThrow_KeyExists_ReturnsCorrectValue()
+	{
+		var dictionary = new Dictionary<string, int> { { "key", 1 } };
+		var result     = dictionary.GetValueOrThrow("key", "Key not found");
+		Assert.Equal(1, result);
+	}
+
+	[Fact]
+	public void GetValueOrThrow_KeyDoesNotExist_ThrowsException()
+	{
+		var dictionary = new Dictionary<string, int>();
+		Assert.Throws<KeyNotFoundException>(() => dictionary.GetValueOrThrow("key", "Key not found"));
+	}
+
+	[Fact]
+	public void GetValueSafe_KeyExists_ReturnsCorrectValue()
+	{
+		var dictionary = new Dictionary<string, int> { { "key", 1 } };
+		var result     = dictionary.GetValueSafe("key");
+		Assert.Equal(1, result);
+	}
+
+	[Fact]
+	public void GetValueSafe_KeyDoesNotExist_ReturnsDefaultValue()
+	{
+		var dictionary = new Dictionary<string, int>();
+		var result     = dictionary.GetValueSafe("key");
+		Assert.Equal(0, result);
+	}
+
+	[Fact]
+	public void TryGetValueSafe_KeyExists_ReturnsTrueAndCorrectValue()
+	{
+		var dictionary = new Dictionary<string, int> { { "key", 1 } };
+		var result     = dictionary.TryGetValueSafe("key", out var value);
+		Assert.True(result);
+		Assert.Equal(1, value);
+	}
+
+	[Fact]
+	public void TryGetValueSafe_KeyDoesNotExist_ReturnsFalse()
+	{
+		var dictionary = new Dictionary<string, int>();
+		var result     = dictionary.TryGetValueSafe("key", out var value);
+		Assert.False(result);
+		Assert.Equal(0, value);
+		Assert.Equal(default, value);
+	}
+}

--- a/System/tests/Extensions/EnumExtensionsTests.cs
+++ b/System/tests/Extensions/EnumExtensionsTests.cs
@@ -3,8 +3,6 @@
 using System.ComponentModel;
 using System.Runtime.Serialization;
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class EnumExtensionsTests

--- a/System/tests/Extensions/EnumValuesTests.cs
+++ b/System/tests/Extensions/EnumValuesTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class EnumValuesTests

--- a/System/tests/Extensions/Strings/StringAccentTests.cs
+++ b/System/tests/Extensions/Strings/StringAccentTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringAccentTests

--- a/System/tests/Extensions/Strings/StringEnsureEndTests.cs
+++ b/System/tests/Extensions/Strings/StringEnsureEndTests.cs
@@ -2,8 +2,6 @@
 
 using System.Globalization;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringEnsureEndTests

--- a/System/tests/Extensions/Strings/StringEnsureStartTests.cs
+++ b/System/tests/Extensions/Strings/StringEnsureStartTests.cs
@@ -2,8 +2,6 @@
 
 using System.Globalization;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringEnsureStartTests

--- a/System/tests/Extensions/Strings/StringEnumTests.cs
+++ b/System/tests/Extensions/Strings/StringEnumTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringEnumTests

--- a/System/tests/Extensions/Strings/StringEscapeTests.cs
+++ b/System/tests/Extensions/Strings/StringEscapeTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringEscapeTests

--- a/System/tests/Extensions/Strings/StringNullTests.cs
+++ b/System/tests/Extensions/Strings/StringNullTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringNullTests

--- a/System/tests/Extensions/Strings/StringRemoveFix.cs
+++ b/System/tests/Extensions/Strings/StringRemoveFix.cs
@@ -2,8 +2,6 @@
 
 using System.Globalization;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringRemoveFix

--- a/System/tests/Extensions/Strings/StringSelectorTests.cs
+++ b/System/tests/Extensions/Strings/StringSelectorTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSelectorTests

--- a/System/tests/Extensions/Strings/StringSeparationListTests.cs
+++ b/System/tests/Extensions/Strings/StringSeparationListTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSeparationListTests

--- a/System/tests/Extensions/Strings/StringSeparationSpaceTests.cs
+++ b/System/tests/Extensions/Strings/StringSeparationSpaceTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSeparationSpaceTests

--- a/System/tests/Extensions/Strings/StringSlashTests.cs
+++ b/System/tests/Extensions/Strings/StringSlashTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSlashTests

--- a/System/tests/Extensions/Strings/StringSlugTests.cs
+++ b/System/tests/Extensions/Strings/StringSlugTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSlugTests

--- a/System/tests/Extensions/Strings/StringSplitTests.cs
+++ b/System/tests/Extensions/Strings/StringSplitTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSplitTests

--- a/System/tests/Extensions/Strings/StringSubstringTests.cs
+++ b/System/tests/Extensions/Strings/StringSubstringTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringSubstringTests

--- a/System/tests/Extensions/Strings/StringTitleCaseTests.cs
+++ b/System/tests/Extensions/Strings/StringTitleCaseTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringTitleCaseTests

--- a/System/tests/Extensions/Strings/StringTrimTests.cs
+++ b/System/tests/Extensions/Strings/StringTrimTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringTrimTests

--- a/System/tests/Extensions/Strings/StringTruncateTests.cs
+++ b/System/tests/Extensions/Strings/StringTruncateTests.cs
@@ -2,8 +2,6 @@
 
 using Wangkanai.Exceptions;
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringTruncateTests

--- a/System/tests/Extensions/Strings/StringUnicodeTests.cs
+++ b/System/tests/Extensions/Strings/StringUnicodeTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Extensions.Strings;
 
 public class StringUnicodeTests

--- a/System/tests/Extensions/TypeExtensionsTests.cs
+++ b/System/tests/Extensions/TypeExtensionsTests.cs
@@ -4,8 +4,6 @@
 
 using System.Numerics;
 
-using Xunit;
-
 namespace Wangkanai.Extensions;
 
 public class TypeExtensionsTests

--- a/System/tests/MathTests.cs
+++ b/System/tests/MathTests.cs
@@ -1,7 +1,5 @@
 // Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai;
 
 public class MathTests

--- a/System/tests/OperatorTests.cs
+++ b/System/tests/OperatorTests.cs
@@ -2,8 +2,6 @@
 
 using System.Numerics;
 
-using Xunit;
-
 namespace Wangkanai;
 
 public class OperatorTests

--- a/System/tests/Reflection/PropertyCopyTests.cs
+++ b/System/tests/Reflection/PropertyCopyTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai.Reflection;
 
 public class PropertyCopyTests

--- a/System/tests/StaticRandomTests.cs
+++ b/System/tests/StaticRandomTests.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using Xunit;
-
 namespace Wangkanai;
 
 public class StaticRandomTests

--- a/System/tests/Usings.cs
+++ b/System/tests/Usings.cs
@@ -3,3 +3,5 @@
 global using System;
 global using System.Collections.Generic;
 global using System.Linq;
+
+global using Xunit;


### PR DESCRIPTION
Changed the logic inside GetValueSafe method to first check if the key is null or if the key does not exist in the dictionary. This change makes the code more readable and maintainable by first checking for exceptions before returning a value.