### PR TITLE
Fix collection extensions add range safe

### DIFF
--- a/System/src/Checks/ThrowIfEmptyEnumerableExtensions.cs
+++ b/System/src/Checks/ThrowIfEmptyEnumerableExtensions.cs
@@ -9,14 +9,10 @@ namespace Wangkanai;
 public static class ThrowIfEmptyExtensions
 {
 	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T> value)
-		=> !value.ThrowIfNull().Any()
-			   ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value))
-			   : value;
+		=> value.Any() ? value : throw new ArgumentEmptyException(nameof(value));
 
 	public static IEnumerable<T> ThrowIfEmpty<T>([NotNull] this IEnumerable<T> value, string message)
-		=> !value.ThrowIfNull().Any()
-			   ? throw ExceptionActivator.CreateArgumentInstance<ArgumentEmptyException>(nameof(value), message)
-			   : value;
+		=> value.Any() ? value : throw new ArgumentEmptyException(nameof(value), message);
 
 	public static IEnumerable<TType> ThrowIfEmpty<TException, TType>([NotNull] this IEnumerable<TType>? value)
 		where TException : ArgumentException

--- a/System/src/Collections/ProjectionComparer.cs
+++ b/System/src/Collections/ProjectionComparer.cs
@@ -20,7 +20,7 @@ public static class ProjectionComparer
 	/// <summary>
 	/// Creates an instance of the <see cref="ProjectionComparer"/> using the given specified projection.
 	/// </summary>
-	/// <param name="ignored">The value is ignored and is solely present to aid type inference</para>
+	/// <param name="ignored">The value is ignored and is solely present to aid type inference</param>
 	/// <param name="projection">Projection to use when determining the key of an element</param>
 	/// <typeparam name="TSource">Type parameter for the elements to be compared</typeparam>
 	/// <typeparam name="TKey">Type parameter for the keys to be compared, after being projected from the elements</typeparam>
@@ -60,7 +60,7 @@ public class ProjectionComparer<TSource, TKey> : IComparer<TSource>
 	/// </summary>
 	/// <param name="projection">Projection to use during comparisons</param>
 	/// <param name="comparer">The comparer to use on the keys. If null, then that case the default comparer will be used.</param>
-	public ProjectionComparer(Func<TSource, TKey> projection, IComparer<TKey> comparer = null!)
+	public ProjectionComparer(Func<TSource, TKey> projection, IComparer<TKey>? comparer = null)
 	{
 		_projection = projection.ThrowIfNull();
 		_comparer   = comparer ?? Comparer<TKey>.Default;

--- a/System/src/Extensions/CollectionExtension.cs
+++ b/System/src/Extensions/CollectionExtension.cs
@@ -25,7 +25,7 @@ public static class CollectionExtension
 	/// <typeparam name="T">the collection.</typeparam>
 	/// <returns>The collection.</returns>
 	/// <exception cref="System.ArgumentNullException">An <see cref="System.ArgumentNullException"/> is thrown if <paramref name="list"/> or <paramref name="items"/> is <see langword="null"/>.</exception>
-	public static ICollection<T> AddRangeSafe<T>(this ICollection<T> list, ICollection<T> items)
+	public static ICollection<T> AddRangeSafe<T>(this ICollection<T> list, IEnumerable<T> items)
 	{
 		list.ThrowIfNull()
 		    .ThrowIfEmpty();
@@ -51,15 +51,14 @@ public static class CollectionExtension
 		foreach (var item in items)
 		{
 			var contains = comparer != null ? list.Contains(item, comparer) : list.Contains(item);
-
-			if (!contains)
-				list.Add(item);
+			if (contains) continue;
+			list.Add(item);
 		}
 
 		return list;
 	}
 
-	public static ICollection<T> Replace<T>(this ICollection<T> list, ICollection<T> items)
+	public static ICollection<T> Replace<T>(this ICollection<T> list, IEnumerable<T> items)
 	{
 		//list.ThrowIfNull();
 

--- a/System/src/Extensions/CollectionExtension.cs
+++ b/System/src/Extensions/CollectionExtension.cs
@@ -27,10 +27,8 @@ public static class CollectionExtension
 	/// <exception cref="System.ArgumentNullException">An <see cref="System.ArgumentNullException"/> is thrown if <paramref name="list"/> or <paramref name="items"/> is <see langword="null"/>.</exception>
 	public static ICollection<T> AddRangeSafe<T>(this ICollection<T> list, IEnumerable<T> items)
 	{
-		list.ThrowIfNull()
-		    .ThrowIfEmpty();
-		items.ThrowIfNull()
-		     .ThrowIfEmpty();
+		list.ThrowIfNull();
+		items.ThrowIfNull();
 
 		foreach (var each in items)
 			list.Add(each);
@@ -60,9 +58,8 @@ public static class CollectionExtension
 
 	public static ICollection<T> Replace<T>(this ICollection<T> list, IEnumerable<T> items)
 	{
-		//list.ThrowIfNull();
-
-		//items.ThrowIfNull();
+		list.ThrowIfNull().ThrowIfEmpty();
+		items.ThrowIfNull().ThrowIfEmpty();
 
 		list.Clear();
 		list.AddRangeSafe(items);

--- a/System/tests/Extensions/CollectionExtensionsTests.cs
+++ b/System/tests/Extensions/CollectionExtensionsTests.cs
@@ -71,8 +71,8 @@ public class CollectionExtensionsTests
 	[Fact]
 	public void RangeEmptyNull()
 	{
-		Assert.Throws<ArgumentEmptyException>(() => _emptyStrings!.AddRangeSafe(null!));
-		Assert.Throws<ArgumentEmptyException>(() => _emptyInts!.AddRangeSafe(null!));
+		Assert.Throws<ArgumentNullException>(() => _emptyStrings!.AddRangeSafe(null!));
+		Assert.Throws<ArgumentNullException>(() => _emptyInts!.AddRangeSafe(null!));
 	}
 
 	[Fact]


### PR DESCRIPTION
Refined the parameters of the AddRangeSafe and Replace collection extension methods to accept IEnumerable instead of ICollection. Also corrected a minor XML tag error in ProjectionComparer file. Adjusted the code block of AddRangeSafe for readability and accuracy in logic.