### PR TITLE
Update version to 2.3 in sonar scripts

### DIFF
--- a/sonar-begin.ps1
+++ b/sonar-begin.ps1
@@ -1,6 +1,6 @@
 $buildDir    = $env:AGENT_BUILDDIRECTORY
 $sourceDir   = $env:BUILD_SOURCESDIRECTORY
-$version     = 2.2
+$version     = 2.3
 
 write-host "Agent.BuildDirectory:  " $buildDir
 write-host "Build.SourcesDirectoy: " $sourceDir

--- a/sonar-prep.ps1
+++ b/sonar-prep.ps1
@@ -1,6 +1,6 @@
 $buildDir    = $env:AGENT_BUILDDIRECTORY
 $sourceDir   = $env:BUILD_SOURCESDIRECTORY
-$version     = 2.2
+$version     = 2.3
 
 # Get-ChildItem -Path Env:\ | Format-List
 


### PR DESCRIPTION
The version variable in both sonar-prep.ps1 and sonar-begin.ps1 has been updated to reflect the latest version, 2.3. This ensures the scripts are referring and working with the most recent version.