### PR TITLE
Add SpanExtensions class with IsEmpty method

### DIFF
--- a/System/src/Extensions/SpanExtensions.cs
+++ b/System/src/Extensions/SpanExtensions.cs
@@ -4,6 +4,12 @@ namespace Wangkanai.Extensions;
 
 public static class SpanExtensions
 {
+	public static bool IsNull<T>([NotNull] this Span<T> span)
+		=> span == null;
+
 	public static bool IsEmpty<T>([NotNull] this Span<T> span)
 		=> span.Length == 0;
+
+	public static bool IsNullOrEmpty<T>([NotNull] this Span<T> span)
+		=> span == null || span.Length == 0;
 }

--- a/System/src/Extensions/SpanExtensions.cs
+++ b/System/src/Extensions/SpanExtensions.cs
@@ -1,0 +1,9 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Extensions;
+
+public static class SpanExtensions
+{
+	public static bool IsEmpty<T>([NotNull] this Span<T> span)
+		=> span.Length == 0;
+}

--- a/System/tests/Extensions/SpanExtensionsTests.cs
+++ b/System/tests/Extensions/SpanExtensionsTests.cs
@@ -1,0 +1,47 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Extensions;
+
+public class SpanExtensionsTests
+{
+	[Fact]
+	public void IsNull()
+	{
+		// Arrange
+		Span<int> _null = null;
+
+		// Act
+		var result = _null.IsNull();
+
+		// Assert
+		Assert.True(result);
+
+	}
+
+	[Fact]
+	public void IsEmpty()
+	{
+		// Arrange
+		var span = new Span<int>();
+
+		// Act
+		var result = span.IsEmpty();
+
+		// Assert
+		Assert.True(result);
+	}
+
+	[Fact]
+	public void IsNullOrEmpty()
+	{
+		// Arrange
+		Span<int> _null = null;
+		Span<int> _empty = new Span<int>();
+		Span<int> _span = new Span<int>(new int[] { 1, 2, 3 });
+
+		// Assert
+		Assert.True(_null.IsNullOrEmpty());
+		Assert.True(_empty.IsNullOrEmpty());
+		Assert.False(_span.IsNullOrEmpty());
+	}
+}


### PR DESCRIPTION
A new class called SpanExtensions has been introduced in the Extensions namespace. This class includes an IsEmpty method, which checks if a given span is empty by comparing its length to 0.