### PR TITLE
Update enum extension methods and tests

### DIFF
--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -80,7 +80,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 		if (indexOfOpera != -1)
 			return agent.Substring(indexOfOpera + "opr/".Length).ToVersion();
 
-		var name           = browser.ToStringInvariant();
+		var name           = browser.ToStringMistake();
 		var first          = agent.IndexOf(name, StringComparison.Ordinal);
 		var cut            = agent.Length > first + name.Length + 1 ? agent.Substring(first + name.Length + 1) : agent.Substring(first + name.Length);
 		var text           = "version/";
@@ -124,7 +124,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 	private static Version GetVersionCommon(string agent, Browser browser)
 	{
-		var name  = browser.ToStringInvariant();
+		var name  = browser.ToStringMistake();
 		var first = agent.IndexOf(name, StringComparison.Ordinal);
 
 		if (first < 0 || first + name.Length > agent.Length)

--- a/Detection/src/Services/CrawlerService.cs
+++ b/Detection/src/Services/CrawlerService.cs
@@ -9,7 +9,7 @@ namespace Wangkanai.Detection.Services;
 public sealed class CrawlerService : ICrawlerService
 {
 	private static readonly (string, Crawler)[] Crawlers =
-		EnumValues<Crawler>.GetValues().Select(x => (x.ToStringInvariant(), x)).ToArray();
+		EnumValues<Crawler>.GetValues().Select(x => (x.ToStringMistake(), x)).ToArray();
 
 	private static readonly IndexTree         CrawlerIndex = Crawlers.Select(x => x.Item1).BuildIndexTree();
 	private readonly        DetectionOptions  _options;

--- a/Detection/src/Services/PlatformService.cs
+++ b/Detection/src/Services/PlatformService.cs
@@ -140,11 +140,11 @@ public sealed class PlatformService : IPlatformService
 
 	private static readonly string[]  X86DeviceList     = { "i86", "i686", Processor.x86.ToString() };
 	private static readonly IndexTree X86DeviceIndex    = X86DeviceList.BuildIndexTree();
-	private static readonly string[]  X64DeviceList     = { "x86_64", "wow64", "win64", Processor.x64.ToStringInvariant() };
+	private static readonly string[]  X64DeviceList     = { "x86_64", "wow64", "win64", Processor.x64.ToStringMistake() };
 	private static readonly IndexTree X64DeviceIndex    = X64DeviceList.BuildIndexTree();
-	private static readonly string[]  IosDeviceList     = { "iphone", "ipod", Platform.iOS.ToStringInvariant() };
+	private static readonly string[]  IosDeviceList     = { "iphone", "ipod", Platform.iOS.ToStringMistake() };
 	private static readonly IndexTree IosDeviceIndex    = IosDeviceList.BuildIndexTree();
-	private static readonly string[]  IPadosDeviceList  = { "ipad", Platform.iPadOS.ToStringInvariant() };
+	private static readonly string[]  IPadosDeviceList  = { "ipad", Platform.iPadOS.ToStringMistake() };
 	private static readonly IndexTree IPadosDeviceIndex = IPadosDeviceList.BuildIndexTree();
 	private static readonly string[]  ChromeOSList      = { "cros" };
 	private static readonly IndexTree ChromeOSIndex     = ChromeOSList.BuildIndexTree();

--- a/System/src/Extensions/EnumExtensions.cs
+++ b/System/src/Extensions/EnumExtensions.cs
@@ -8,15 +8,23 @@ namespace Wangkanai.Extensions;
 public static class EnumExtensions
 {
 	[DebuggerStepThrough]
-	public static string ToStringInvariant<T>(this T value) where T : Enum
-		=> EnumValues<T>.GetName(value).ToLowerInvariant();
+	public static string ToStringMistake<T>(this T value) where T : Enum
+		=> EnumValues<T>.GetNameMistake(value).ToLowerInvariant();
+
+	[DebuggerStepThrough]
+	public static string ToLowerString<T>(this T value) where T : Enum
+		=> EnumValues<T>.GetNameOriginal(value).ToLowerInvariant();
+
+	[DebuggerStepThrough]
+	public static string ToUpperString<T>(this T value) where T : Enum
+		=> EnumValues<T>.GetNameOriginal(value).ToUpperInvariant();
 
 	[DebuggerStepThrough]
 	public static bool Contains<T>(this string agent, T flags) where T : Enum
 		=> EnumValues<T>.TryGetSingleName(flags, out var value)
 			   ? agent.Contains(value, StringComparison.Ordinal)
 			   : flags.GetFlags()
-			          .Any(item => agent.Contains(ToStringInvariant(item), StringComparison.Ordinal));
+			          .Any(item => agent.Contains(ToStringMistake(item), StringComparison.Ordinal));
 
 	[DebuggerStepThrough]
 	public static IEnumerable<T> GetFlags<T>(this T value) where T : Enum

--- a/System/src/Extensions/EnumValues.cs
+++ b/System/src/Extensions/EnumValues.cs
@@ -24,8 +24,8 @@ public static class EnumValues<T> where T : Enum
 	public static bool TryGetSingleName(T value, out string result)
 		=> Names.TryGetValue(value, out result!);
 
-	[DebuggerStepThrough]
-	public static string GetName(T value)
+	[Obsolete]
+	public static string GetNameMistake(T value)
 		=> Names.TryGetValue(value, out var result)
 			   ? result
 			   : string.Join(',', value.GetFlags().Select(x => Names[x]));
@@ -41,6 +41,13 @@ public static class EnumValues<T> where T : Enum
 
 	private static Dictionary<T, string> Names
 		=> Values.ToDictionary(value => value, value => value.ToString().ToLowerInvariant());
+
+	private static Dictionary<T, string> NamesLower
+		=> Values.ToDictionary(value => value, value => value.ToString().ToLowerInvariant());
+
+	private static Dictionary<T, string> NamesUpper
+		=> Values.ToDictionary(value => value, value => value.ToString().ToUpperInvariant());
+
 
 	private static Dictionary<T, string> NamesOriginal
 		=> Values.ToDictionary(value => value, value => value.ToString());

--- a/System/tests/Extensions/EnumExtensionsTests.cs
+++ b/System/tests/Extensions/EnumExtensionsTests.cs
@@ -24,15 +24,22 @@ public class EnumExtensionsTests
 	public void ToStringInvariant()
 	{
 		var one = Country.Thailand;
-		Assert.Equal("thailand", one.ToStringInvariant());
+		Assert.Equal("thailand", one.ToStringMistake());
 	}
 
-	// [Fact]
-	// public void ToStringInvariantFlag()
-	// {
-	// 	var flags = Country.Singapore;
-	// 	Assert.Equal("thailand,singapore", flags.ToStringInvariant());
-	// }
+	[Fact]
+	public void ToLowerString_FlagSingle()
+	{
+		var flags = Country.Singapore;
+		Assert.Equal("singapore", flags.ToStringMistake());
+	}
+
+	[Fact]
+	public void ToLowerString_FlagTwo()
+	{
+		var flags = Country.Thailand | Country.Singapore;
+		Assert.Equal("thailand,singapore", flags.ToStringMistake());
+	}
 
 	[Fact]
 	public void EnumItemDescription()
@@ -54,8 +61,8 @@ public class EnumExtensionsTests
 [Flags]
 public enum Country
 {
-	[Description("ประเทศไทย")] Thailand  = 0,
-	[EnumMember(Value = "jp")] Japan     = 1 << 0,
-	[EnumMember(Value = "sg")] Singapore = 1 << 1,
-	[EnumMember(Value = "au")] Australia = 1 << 2
+	[Description("ประเทศไทย")] Thailand  = 1 << 0,
+	[EnumMember(Value = "jp")] Japan     = 1 << 1,
+	[EnumMember(Value = "sg")] Singapore = 1 << 2,
+	[EnumMember(Value = "au")] Australia = 1 << 3
 }


### PR DESCRIPTION
The ToStringInvariant() methods have been replaced with ToStringMistake(), ToLowerString() and ToUpperString() across different files including EnumExtensions.cs and various test files. Additionally, adjusted Enum and Country values for more consistency and readability. The resulting code allows for more flexible and case-sensitive string conversions and more accurate and meaningful tests.