### PR TITLE
Rename FormattingExtensions to BinaryScalingExtensions

### DIFF
--- a/System/src/Extensions/BinaryScalingExtensions.cs
+++ b/System/src/Extensions/BinaryScalingExtensions.cs
@@ -7,6 +7,10 @@ public static class BinaryScalingExtensions
 	private static readonly string[] Sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
 	[DebuggerStepThrough]
+	public static string ToHumanReadable(this short length)
+		=> ((long)length).ToHumanReadable();
+
+	[DebuggerStepThrough]
 	public static string ToHumanReadable(this int length)
 		=> ((long)length).ToHumanReadable();
 
@@ -14,11 +18,21 @@ public static class BinaryScalingExtensions
 	public static string ToHumanReadable(this long length)
 	{
 		var order = 0;
-		while (length >= 1024 && order + 1 < Sizes.Length)
-		{
-			order++;
-			length /= 1024;
-		}
+		// positive
+		if (length >= 0)
+			while (length >= 1024 && order + 1 < Sizes.Length)
+			{
+				order++;
+				length /= 1024;
+			}
+
+		// negative
+		if (length < 0)
+			while (length <= -1024 && order + 1 < Sizes.Length)
+			{
+				order++;
+				length /= 1024;
+			}
 
 		return $"{length:0.##} {Sizes[order]}";
 	}
@@ -26,7 +40,7 @@ public static class BinaryScalingExtensions
 	[DebuggerStepThrough]
 	public static string ToHumanReadable(this ulong length)
 	{
-		int order = 0;
+		var order = 0;
 		while (length >= 1024 && order + 1 < Sizes.Length)
 		{
 			order++;

--- a/System/src/Extensions/BinaryScalingExtensions.cs
+++ b/System/src/Extensions/BinaryScalingExtensions.cs
@@ -2,9 +2,9 @@
 
 namespace Wangkanai.Extensions;
 
-public static class FormattingExtensions
+public static class BinaryScalingExtensions
 {
-	private static readonly string[] Sizes = { "B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB" };
+	private static readonly string[] Sizes = ["B", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
 	[DebuggerStepThrough]
 	public static string ToHumanReadable(this int length)

--- a/System/tests/Extensions/BinaryScalingExtensionsTests.cs
+++ b/System/tests/Extensions/BinaryScalingExtensionsTests.cs
@@ -1,0 +1,122 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Extensions;
+
+using Xunit;
+
+using Wangkanai.Extensions;
+
+public class BinaryScalingExtensionsTests
+{
+	[Fact]
+	public void ConvertsBytesToHumanReadableFormat()
+	{
+		var value    = 1024; // 1 KB in bytes
+		var expected = "1 KB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertsLargeNumberToHumanReadableFormat()
+	{
+		var value    = 1048576; // 1 MB in bytes
+		var expected = "1 MB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertsZeroBytesToHumanReadableFormat()
+	{
+		var value    = 0;
+		var expected = "0 B";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertsNegativeNumber()
+	{
+		var value    = -1024;
+		var expected = "-1 KB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertsNegativeLargeNumber()
+	{
+		var value    = -1048576;
+		var expected = "-1 MB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertLongGiga()
+	{
+		var value    = 1024L * 1024L * 1024L; // 1 GB in bytes
+		var expected = "1 GB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertLongTera()
+	{
+		var value    = 1024L * 1024L * 1024L * 1024L; // 1 TB in bytes
+		var expected = "1 TB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertLongPeta()
+	{
+		var value    = 1024L * 1024L * 1024L * 1024L * 1024L; // 1 PB in bytes
+		var expected = "1 PB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertLongExa()
+	{
+		var value    = 1024L * 1024L * 1024L * 1024L * 1024L * 1024L; // 1 EB in bytes
+		var expected = "1 EB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertULongGiga()
+	{
+		var value    = 1024UL * 1024UL * 1024UL; // 1 GB in bytes
+		var expected = "1 GB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertULongTera()
+	{
+		var value    = 1024UL * 1024UL * 1024UL * 1024UL; // 1 TB in bytes
+		var expected = "1 TB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertULongPeta()
+	{
+		var value    = 1024UL * 1024UL * 1024UL * 1024UL * 1024UL; // 1 PB in bytes
+		var expected = "1 PB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertULongExa()
+	{
+		var value    = 1024UL * 1024UL * 1024UL * 1024UL * 1024UL * 1024UL; // 1 EB in bytes
+		var expected = "1 EB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+
+	[Fact]
+	public void ConvertShortKilo()
+	{
+		var value    = (short)1024; // 1 KB in bytes
+		var expected = "1 KB";
+		Assert.Equal(expected, value.ToHumanReadable());
+	}
+}


### PR DESCRIPTION
The file and class have been renamed from FormattingExtensions to BinaryScalingExtensions to better align with the functionality. The Sizes array has also been updated to better represent binary scaling.