### PR TITLE
Add StreamExtensionsTests for StreamExtensions methods

### DIFF
--- a/System/src/Extensions/StreamExtensions.cs
+++ b/System/src/Extensions/StreamExtensions.cs
@@ -10,7 +10,7 @@ public static class StreamExtensions
 		fromStream.ThrowIfNull();
 		toStream.ThrowIfNull();
 
-		var bytes = new byte[8092];
+		var bytes = new byte[16 * 1024];
 		int dataRead;
 		while ((dataRead = fromStream.Read(bytes, 0, bytes.Length)) > 0)
 			toStream.Write(bytes, 0, dataRead);
@@ -21,7 +21,7 @@ public static class StreamExtensions
 	{
 		stream.ThrowIfNull();
 
-		byte[]    buffer = new byte[16 * 1024];
+		var       buffer = new byte[16 * 1024];
 		using var ms     = new MemoryStream();
 		int       read;
 		while ((read = stream.Read(buffer, 0, buffer.Length)) > 0)

--- a/System/src/Extensions/StreamExtensions.cs
+++ b/System/src/Extensions/StreamExtensions.cs
@@ -1,7 +1,5 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-using System.IO;
-
 namespace Wangkanai.Extensions;
 
 public static class StreamExtensions

--- a/System/tests/Extensions/StreamExtensionsTests.cs
+++ b/System/tests/Extensions/StreamExtensionsTests.cs
@@ -1,0 +1,87 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Extensions;
+
+public class StreamExtensionsTests
+{
+	[Fact]
+	public void CopyTo()
+	{
+		// Arrange
+		var fromStream = new MemoryStream();
+		var toStream   = new MemoryStream();
+		var bytes      = new byte[8092];
+		fromStream.Write(bytes, 0, bytes.Length);
+		fromStream.Position = 0;
+
+		// Act
+		fromStream.CopyTo(toStream);
+
+		// Assert
+		Assert.Equal(fromStream.Length, toStream.Length);
+	}
+
+	[Fact]
+	public void ReadFully()
+	{
+		// Arrange
+		var stream = new MemoryStream();
+		var bytes  = new byte[8092];
+		stream.Write(bytes, 0, bytes.Length);
+		stream.Position = 0;
+
+		// Act
+		var result = stream.ReadFully();
+
+		// Assert
+		Assert.Equal(stream.Length, result.Length);
+	}
+
+	[Fact]
+	public void ReadToString()
+	{
+		// Arrange
+		var length = 8092;
+		var stream = new MemoryStream();
+		var bytes  = new byte[length];
+		stream.Write(bytes, 0, length);
+		stream.Position = 0;
+
+		// Act
+		var result = stream.ReadToString();
+
+		// Assert
+		Assert.Equal(length, result.Length);
+	}
+
+	[Fact]
+	public void ReadToString_Null()
+	{
+		// Arrange
+		Stream stream = null;
+
+		// Assert
+		Assert.Throws<ArgumentNullException>(() => stream.ReadToString());
+	}
+
+	[Fact]
+	public void ReadFully_Null()
+	{
+		// Arrange
+		Stream stream = null!;
+
+		// Assert
+		Assert.Throws<ArgumentNullException>(() => stream.ReadFully());
+	}
+
+	[Fact]
+	public void CopyTo_Null()
+	{
+		// Arrange
+		Stream fromStream = null!;
+		var    toStream   = new MemoryStream();
+
+		// Assert
+		Assert.Throws<NullReferenceException>(() => fromStream.CopyTo(toStream));
+	}
+}


### PR DESCRIPTION
This commit introduces unit tests in the StreamExtensionsTests file to assure that the methods of StreamExtensions class perform as expected. The tests cover the methods: CopyTo, ReadFully, and ReadToString, including cases with null streams.