### PR TITLE
Refactor TreeExtensions and add relevant tests

### DIFF
--- a/System/src/Extensions/TreeExtensions.cs
+++ b/System/src/Extensions/TreeExtensions.cs
@@ -10,14 +10,14 @@ public static class TreeExtensions
 		yield return node;
 
 		var childNodes = children(node);
-		if (children.TrueIfNull()) 
+		if (children.TrueIfNull())
 			yield break;
 		foreach (var child in childNodes.SelectMany(n => n.Traverse(children)))
 			yield return child;
 	}
 
 	[DebuggerStepThrough]
-	public static IEnumerable<T> GetAncestors<T>(T item, Func<T, T> getParentFunc)
+	public static IEnumerable<T> GetAncestors<T>(this T item, Func<T, T> getParentFunc)
 	{
 		getParentFunc.ThrowIfNull();
 

--- a/System/tests/Extensions/TreeExtensionsTests.cs
+++ b/System/tests/Extensions/TreeExtensionsTests.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Extensions;
+
+public class TreeExtensionsTests
+{
+	[Fact]
+	public void Traverse()
+	{
+		var root = new Node<int>(1)
+		           {
+			           Children = new List<Node<int>>
+			                      {
+				                      new Node<int>(2)
+				                      {
+					                      Children = new List<Node<int>>
+					                                 {
+						                                 new Node<int>(3)
+					                                 }
+				                      }
+			                      }
+		           };
+
+		var result = root.Traverse(n => n.Children).ToList();
+		Assert.Equal(3, result.Count);
+		Assert.Equal(1, result[0].Value);
+		Assert.Equal(2, result[1].Value);
+		Assert.Equal(3, result[2].Value);
+	}
+}
+
+public class Node<T>(T value)
+	where T : struct
+{
+	public T             Value    { get; set; } = value;
+	public List<Node<T>> Children { get; set; } = new();
+}


### PR DESCRIPTION
This commit updates the `GetAncestors` method in the `TreeExtensions.cs` by adding 'this' keyword to make it an extension method. It also ensures coding style consistency by adjusting whitespace. Additionally, the `TreeExtensionsTests.cs` file is created to include unit tests for the `Traverse` method, ensuring the correct functionality of these methods.