### PR TITLE
Add more test methods and refactor AbstractTypeFactory

### DIFF
--- a/System/src/Domain/AbstractTypeFactory.cs
+++ b/System/src/Domain/AbstractTypeFactory.cs
@@ -63,20 +63,11 @@ public static class AbstractTypeFactory<TBaseType>
 		where T : TBaseType
 		=> (T)TryCreateInstance(typeof(T).Name)!;
 
-	public static TBaseType TryCreateInstance(string typeName, TBaseType defaultObj)
-	{
-		TBaseType result   = defaultObj;
-		var       typeInfo = FindTypeInfoByName(typeName);
-		if (typeInfo.FalseIfNull())
-			result = TryCreateInstance(typeName);
-
-		return result;
-	}
 
 	public static TBaseType TryCreateInstance(string typeName)
 	{
-		TBaseType result;
-		var       typeInfo = FindTypeInfoByName(typeName);
+		TBaseType                  result;
+		GenericTypeInfo<TBaseType> typeInfo = FindTypeInfoByName(typeName);
 		if (typeInfo.FalseIfNull())
 		{
 			if (typeInfo.Factory != null)
@@ -98,12 +89,13 @@ public static class AbstractTypeFactory<TBaseType>
 		return result;
 	}
 
+
 	public static GenericTypeInfo<TBaseType> FindTypeInfoByName(string typeName)
 	{
 		// Try find first direct type match from registered types
 		var result = TypeInfos.Find(x => x.TypeName.EqualsInvariant(typeName));
 		// Then need to find in inheritance chain from registered types
-		if (result.TrueIfNull())
+		if (result != null)
 			result = TypeInfos.First(x => x.IsAssignableTo(typeName));
 
 		return result!;

--- a/System/tests/Domain/AbstractTypeFactoryTests.cs
+++ b/System/tests/Domain/AbstractTypeFactoryTests.cs
@@ -55,6 +55,73 @@ public class AbstractTypeFactoryTests
 		Assert.DoesNotContain(child.Type, parent.GetAllSubclasses());
 	}
 
+	[Fact]
+	public void OverrideType()
+	{
+		var parent = AbstractTypeFactory<Parent>.RegisterType<Parent>();
+		var child  = AbstractTypeFactory<Child>.RegisterType<Child>();
+		var result = AbstractTypeFactory<Parent>.OverrideType<Parent, Child>();
+		Assert.Equal(child.Type, result.Type);
+		Assert.Equal(child.TypeName, result.TypeName);
+	}
+
+	[Fact]
+	public void TryCreateInstance()
+	{
+		var parent = AbstractTypeFactory<Parent>.RegisterType<Parent>();
+		var child  = AbstractTypeFactory<Child>.RegisterType<Child>();
+		var result = AbstractTypeFactory<Parent>.TryCreateInstance();
+		Assert.NotNull(result);
+		Assert.IsType<Parent>(result);
+	}
+
+	[Fact]
+	public void TryCreateInstance_Generic()
+	{
+		var parent = AbstractTypeFactory<Parent>.RegisterType<Parent>();
+		var child  = AbstractTypeFactory<Child>.RegisterType<Child>();
+		var result = AbstractTypeFactory<Parent>.TryCreateInstance<Parent>();
+		Assert.NotNull(result);
+		Assert.IsType<Parent>(result);
+	}
+
+
+	[Fact]
+	public void TryCreateInstance_TypeName()
+	{
+		var parent = AbstractTypeFactory<Parent>.RegisterType<Parent>();
+		var child  = AbstractTypeFactory<Child>.RegisterType<Child>();
+		var result = AbstractTypeFactory<Parent>.TryCreateInstance("Parent");
+		Assert.NotNull(result);
+		Assert.IsType<Parent>(result);
+	}
+
+	[Fact]
+	public void FindTypeInfoByName_ShouldReturnTypeInfo_WhenTypeIsRegistered()
+	{
+		// Arrange
+		AbstractTypeFactory<object>.RegisterType<string>();
+
+		// Act
+		var result = AbstractTypeFactory<object>.FindTypeInfoByName("String");
+
+		// Assert
+		Assert.Equal(typeof(string), result.Type);
+	}
+
+	[Fact]
+	public void FindTypeInfoByName_ShouldReturnNull_WhenTypeIsNotRegistered()
+	{
+		// Arrange
+		AbstractTypeFactory<object>.RegisterType<string>();
+
+		// Act
+		var result = AbstractTypeFactory<object>.FindTypeInfoByName("Int");
+
+		// Assert
+		Assert.Null(result);
+	}
+
 	private void RegisterType<T>(GenericTypeInfo<T> expected, GenericTypeInfo<T> actual)
 	{
 		Assert.Equal(expected.Type, actual.Type);


### PR DESCRIPTION
Several new test methods were added to AbstractTypeFactoryTests.cs to improve test coverage for the AbstractTypeFactory class. Additionally, the AbstractTypeFactory.cs file was refactored and simplified by removing the TryCreateInstance function that accepted two parameters. Lastly, the FindTypeInfoByName method has been updated to use clear null checks.