### PR TITLE
Replace 'ToStringMistake' calls with 'ToLowerString' and simplify code

### DIFF
--- a/Detection/src/Models/Browser.cs
+++ b/Detection/src/Models/Browser.cs
@@ -5,13 +5,13 @@ namespace Wangkanai.Detection.Models;
 [Flags]
 public enum Browser
 {
-	Unknown          = 0,
-	Chrome           = 1 << 0, // Google Chrome
-	InternetExplorer = 1 << 1, // Microsoft Internet Explorer
-	Safari           = 1 << 2, // Apple Safari
-	Firefox          = 1 << 3, // Firefox
-	Edge             = 1 << 4, // Microsoft Edge
-	Opera            = 1 << 5, // Opera
-	GoogleSearchApp  = 1 << 6, // Google Search App
-	Others           = 1 << 7  // Others
+	Unknown          = 1 << 0,
+	Chrome           = 1 << 1, // Google Chrome
+	InternetExplorer = 1 << 2, // Microsoft Internet Explorer
+	Safari           = 1 << 3, // Apple Safari
+	Firefox          = 1 << 4, // Firefox
+	Edge             = 1 << 5, // Microsoft Edge
+	Opera            = 1 << 6, // Opera
+	GoogleSearchApp  = 1 << 7, // Google Search App
+	Others           = 1 << 8  // Others
 }

--- a/Detection/src/Models/Crawler.cs
+++ b/Detection/src/Models/Crawler.cs
@@ -5,15 +5,15 @@ namespace Wangkanai.Detection.Models;
 [Flags]
 public enum Crawler
 {
-	Unknown  = 0,
-	Google   = 1 << 0,
-	Bing     = 1 << 1,
-	Yahoo    = 1 << 2,
-	Baidu    = 1 << 3,
-	Facebook = 1 << 4,
-	Twitter  = 1 << 5,
-	LinkedIn = 1 << 6,
-	WhatsApp = 1 << 7,
-	Skype    = 1 << 8,
-	Others   = 1 << 9
+	Unknown  = 1 << 0,
+	Google   = 1 << 1,
+	Bing     = 1 << 2,
+	Yahoo    = 1 << 3,
+	Baidu    = 1 << 4,
+	Facebook = 1 << 5,
+	Twitter  = 1 << 6,
+	LinkedIn = 1 << 7,
+	WhatsApp = 1 << 8,
+	Skype    = 1 << 9,
+	Others   = 1 << 10
 }

--- a/Detection/src/Models/Device.cs
+++ b/Detection/src/Models/Device.cs
@@ -5,13 +5,13 @@ namespace Wangkanai.Detection.Models;
 [Flags]
 public enum Device
 {
-	Unknown = 0,
-	Desktop = 1 << 0, // Windows, Mac, Linux
-	Tablet  = 1 << 1, // iPad, Android
-	Mobile  = 1 << 2, // iPhone, Android
-	Watch   = 1 << 3, // Smart Watch
-	Tv      = 1 << 4, // Samsung, LG
-	Console = 1 << 5, // XBox, Play Station
-	Car     = 1 << 6, // Ford, Toyota
-	IoT     = 1 << 7  // Raspberry Pi
+	Unknown = 1 << 0,
+	Desktop = 1 << 1, // Windows, Mac, Linux
+	Tablet  = 1 << 2, // iPad, Android
+	Mobile  = 1 << 3, // iPhone, Android
+	Watch   = 1 << 4, // Smart Watch
+	Tv      = 1 << 5, // Samsung, LG
+	Console = 1 << 6, // XBox, Play Station
+	Car     = 1 << 7, // Ford, Toyota
+	IoT     = 1 << 8  // Raspberry Pi
 }

--- a/Detection/src/Models/Engine.cs
+++ b/Detection/src/Models/Engine.cs
@@ -5,12 +5,12 @@ namespace Wangkanai.Detection.Models;
 [Flags]
 public enum Engine
 {
-	Unknown = 0,      // Unknown engine
-	WebKit  = 1 << 0, // iOs (Safari, WebViews, Chrome <28) (https://webkit.org/)
-	Blink   = 1 << 1, // Google Chrome, Opera v15+ (https://www.chromium.org/Home)
-	Gecko   = 1 << 2, // Firefox, Netscape (https://hg.mozilla.org/mozilla-central/)
-	Trident = 1 << 3, // IE, Outlook
-	Edge    = 1 << 4, // Microsoft Edge
-	Servo   = 1 << 5, // Mozilla & Samsung (https://github.com/servo/servo)
-	Others  = 1 << 6  // Others
+	Unknown = 1 << 0, // Unknown engine
+	WebKit  = 1 << 1, // iOs (Safari, WebViews, Chrome <28) (https://webkit.org/)
+	Blink   = 1 << 2, // Google Chrome, Opera v15+ (https://www.chromium.org/Home)
+	Gecko   = 1 << 3, // Firefox, Netscape (https://hg.mozilla.org/mozilla-central/)
+	Trident = 1 << 4, // IE, Outlook
+	Edge    = 1 << 5, // Microsoft Edge
+	Servo   = 1 << 6, // Mozilla & Samsung (https://github.com/servo/servo)
+	Others  = 1 << 7  // Others
 }

--- a/Detection/src/Models/Platform.cs
+++ b/Detection/src/Models/Platform.cs
@@ -5,13 +5,13 @@ namespace Wangkanai.Detection.Models;
 [Flags]
 public enum Platform
 {
-	Unknown  = 0,
-	Windows  = 1 << 0, // Microsoft Windows
-	Mac      = 1 << 1, // Apple MacOS
-	iOS      = 1 << 2, // Apple iOS
-	iPadOS   = 1 << 3, // Apple iPadOS
-	Linux    = 1 << 4, // Linux Distribution (Red Hat, Mint, Ubuntu)
-	Android  = 1 << 5, // Google Android
-	ChromeOS = 1 << 6, // Google ChromeOS
-	Others   = 1 << 7  // Others
+	Unknown  = 1 << 0,
+	Windows  = 1 << 1, // Microsoft Windows
+	Mac      = 1 << 2, // Apple MacOS
+	iOS      = 1 << 3, // Apple iOS
+	iPadOS   = 1 << 4, // Apple iPadOS
+	Linux    = 1 << 5, // Linux Distribution (Red Hat, Mint, Ubuntu)
+	Android  = 1 << 6, // Google Android
+	ChromeOS = 1 << 7, // Google ChromeOS
+	Others   = 1 << 8  // Others
 }

--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -45,35 +45,23 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 		var agent   = userAgentService.UserAgent.ToLower();
 		var browser = Name;
 
-		if (string.IsNullOrEmpty(agent))
-			return new Version();
-
 		if (browser == Browser.Edge && !agent.Contains("edge", StringComparison.Ordinal))
 			return GetVersionOf(agent, "edg");
-
 		if (browser == Browser.Edge)
 			return GetVersionEdge(agent);
-
 		if (browser == Browser.GoogleSearchApp)
 			return GetVersionGoogleSearchApp(agent);
-
 		if (browser == Browser.Chrome && agent.Contains("crios", StringComparison.Ordinal))
 			return GetVersionChromeOs(agent);
-
 		if (browser == Browser.Chrome)
 			return GetVersionChrome(agent);
-
 		if (browser == Browser.Safari && agent.Contains("version", StringComparison.Ordinal))
 			return GetVersionSafariVersion(agent);
-
 		if (browser == Browser.Safari)
 			return GetVersionSafariSafari(agent);
-
 		if (browser == Browser.Opera)
 			return GetVersionOpera(agent, browser);
-
-		if (agent.Contains("rv:11.0", StringComparison.Ordinal) ||
-		    agent.Contains("ie 11.0", StringComparison.Ordinal))
+		if (agent.Contains("rv:11.0", StringComparison.Ordinal) || agent.Contains("ie 11.0", StringComparison.Ordinal))
 			return new Version(11, 0);
 		if (agent.Contains("msie 10", StringComparison.Ordinal))
 			return new Version(10, 0);

--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -80,7 +80,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 		if (indexOfOpera != -1)
 			return agent.Substring(indexOfOpera + "opr/".Length).ToVersion();
 
-		var name           = browser.ToStringMistake();
+		var name           = browser.ToLowerString();
 		var first          = agent.IndexOf(name, StringComparison.Ordinal);
 		var cut            = agent.Length > first + name.Length + 1 ? agent.Substring(first + name.Length + 1) : agent.Substring(first + name.Length);
 		var text           = "version/";
@@ -124,7 +124,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 	private static Version GetVersionCommon(string agent, Browser browser)
 	{
-		var name  = browser.ToStringMistake();
+		var name  = browser.ToLowerString();
 		var first = agent.IndexOf(name, StringComparison.Ordinal);
 
 		if (first < 0 || first + name.Length > agent.Length)

--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -93,7 +93,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static Version GetVersionOf(string agent, string value)
 	{
 		var version      = agent.Substring(agent.IndexOf($"{value}/", StringComparison.Ordinal) + $"{value}/".Length);
-		var indexOfSpace = version.IndexOf(" ", StringComparison.Ordinal);
+		var indexOfSpace = version.IndexOf(' ');
 
 		if (indexOfSpace != -1)
 			version = version.Substring(0, indexOfSpace);
@@ -104,7 +104,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static Version GetVersionEdge(string agent)
 	{
 		var version      = agent.Substring(agent.IndexOf("edge/", StringComparison.Ordinal) + "edge/".Length);
-		var indexOfSpace = version.IndexOf(" ", StringComparison.Ordinal);
+		var indexOfSpace = version.IndexOf(' ');
 
 		if (indexOfSpace != -1)
 			version = version.Substring(0, indexOfSpace);
@@ -115,7 +115,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static Version GetVersionGoogleSearchApp(string agent)
 	{
 		var version      = agent.Substring(agent.IndexOf("gsa/", StringComparison.Ordinal) + "gsa/".Length);
-		var indexOfSpace = version.IndexOf(" ", StringComparison.Ordinal);
+		var indexOfSpace = version.IndexOf(' ');
 
 		if (indexOfSpace != -1)
 			version = version.Substring(0, indexOfSpace);
@@ -126,7 +126,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static Version GetVersionSafariVersion(string agent)
 	{
 		var version      = agent.Substring(agent.IndexOf("version/", StringComparison.Ordinal) + "version/".Length);
-		var indexOfSpace = version.IndexOf(" ", StringComparison.Ordinal);
+		var indexOfSpace = version.IndexOf(' ');
 		if (indexOfSpace != -1)
 			version = version.Substring(0, indexOfSpace);
 
@@ -148,7 +148,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static Version GetVersionChromeOs(string agent)
 	{
 		var version      = agent.Substring(agent.IndexOf("crios/", StringComparison.Ordinal) + "crios/".Length);
-		var indexOfSpace = version.IndexOf(" ", StringComparison.Ordinal);
+		var indexOfSpace = version.IndexOf(' ');
 
 		if (indexOfSpace != -1)
 			version = version.Substring(0, indexOfSpace);
@@ -159,7 +159,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static Version GetVersionChrome(string agent)
 	{
 		var version      = agent.Substring(agent.IndexOf("chrome/", StringComparison.Ordinal) + "chrome/".Length);
-		var indexOfSpace = version.IndexOf(" ", StringComparison.Ordinal);
+		var indexOfSpace = version.IndexOf(' ');
 
 		if (indexOfSpace != -1)
 			version = version.Substring(0, indexOfSpace);
@@ -177,7 +177,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 		var cut = agent.Length > first + name.Length + 1 ? agent.Substring(first + name.Length + 1) : agent.Substring(first + name.Length);
 
-		var indexOfSpace = cut.IndexOf(' ', StringComparison.Ordinal);
+		var indexOfSpace = cut.IndexOf(' ');
 		var version      = indexOfSpace != -1 ? cut.Substring(0, indexOfSpace) : cut;
 		return version.ToVersion();
 	}

--- a/Detection/src/Services/CrawlerService.cs
+++ b/Detection/src/Services/CrawlerService.cs
@@ -35,9 +35,8 @@ public sealed class CrawlerService : ICrawlerService
 		if (string.IsNullOrEmpty(agent))
 			return Crawler.Unknown;
 
-		foreach (var crawler in Crawlers)
-			if (agent.Contains(crawler.Key))
-				return crawler.Value;
+		foreach (var crawler in Crawlers.Where(crawler => agent.Contains(crawler.Key)))
+			return crawler.Value;
 
 		return HasOthers(agent, _options.Crawler.Others)
 			       ? Crawler.Others

--- a/Detection/src/Services/CrawlerService.cs
+++ b/Detection/src/Services/CrawlerService.cs
@@ -8,13 +8,8 @@ namespace Wangkanai.Detection.Services;
 
 public sealed class CrawlerService : ICrawlerService
 {
-	private static readonly Dictionary<string, Crawler> Crawlers = EnumValues<Crawler>.GetValues()
-	                                                                                  .Select(x => (x.ToLowerString(), x))
-	                                                                                  .ToDictionary(x => x.Item1, x => x.Item2);
-
-	private static readonly IndexTree         CrawlerIndex = Crawlers.Select(x => x.Key).BuildIndexTree();
-	private readonly        DetectionOptions  _options;
-	private readonly        IUserAgentService _useragent;
+	private readonly DetectionOptions  _options;
+	private readonly IUserAgentService _useragent;
 
 	private Crawler? _name;
 	private Version? _version;
@@ -28,6 +23,8 @@ public sealed class CrawlerService : ICrawlerService
 	public bool    IsCrawler => Name != Crawler.Unknown;
 	public Crawler Name      => _name ??= GetCrawler();
 	public Version Version   => _version ??= GetVersion();
+
+
 
 	private Crawler GetCrawler()
 	{
@@ -63,11 +60,17 @@ public sealed class CrawlerService : ICrawlerService
 		return version.ToVersion();
 	}
 
-	private static bool HasOthers(string agent, IEnumerable<string> others)
+	private  Dictionary<string, Crawler> Crawlers
+		=> EnumValues<Crawler>.GetValues().Select(x => (x.ToLowerString(), x)).ToDictionary(x => x.Item1, x => x.Item2);
+
+	private IndexTree CrawlerIndex
+		=> Crawlers.Select(x => x.Key).BuildIndexTree();
+
+	private bool HasOthers(string agent, IEnumerable<string> others)
 		=> agent.Contains("bot", StringComparison.Ordinal) ||
 		   others.Any(x => agent.Contains(x, StringComparison.Ordinal));
 
-	private static string FindBot(string agent)
+	private string FindBot(string agent)
 		=> agent.Split(' ')
 		        .FirstOrDefault(x => x.SearchContains(CrawlerIndex)) ?? string.Empty;
 }

--- a/Detection/src/Services/CrawlerService.cs
+++ b/Detection/src/Services/CrawlerService.cs
@@ -8,10 +8,12 @@ namespace Wangkanai.Detection.Services;
 
 public sealed class CrawlerService : ICrawlerService
 {
-	private static readonly (string, Crawler)[] Crawlers     = EnumValues<Crawler>.GetValues().Select(x => (x.ToLowerString(), x)).ToArray();
-	private static readonly IndexTree           CrawlerIndex = Crawlers.Select(x => x.Item1).BuildIndexTree();
-	private readonly        DetectionOptions    _options;
-	private readonly        IUserAgentService   _useragent;
+	private static readonly Dictionary<string, Crawler> Crawlers     = EnumValues<Crawler>.GetValues()
+	                                                                                      .Select(x => (x.ToLowerString(), x))
+	                                                                                      .ToDictionary(x => x.Item1, x => x.Item2);
+	private static readonly IndexTree                   CrawlerIndex = Crawlers.Select(x => x.Key).BuildIndexTree();
+	private readonly        DetectionOptions            _options;
+	private readonly        IUserAgentService           _useragent;
 
 	private Crawler? _name;
 	private Version? _version;
@@ -34,8 +36,8 @@ public sealed class CrawlerService : ICrawlerService
 			return Crawler.Unknown;
 
 		foreach (var crawler in Crawlers)
-			if (agent.Contains(crawler.Item1))
-				return crawler.Item2;
+			if (agent.Contains(crawler.Key))
+				return crawler.Value;
 
 		return HasOthers(agent, _options.Crawler.Others)
 			       ? Crawler.Others

--- a/Detection/src/Services/CrawlerService.cs
+++ b/Detection/src/Services/CrawlerService.cs
@@ -8,12 +8,10 @@ namespace Wangkanai.Detection.Services;
 
 public sealed class CrawlerService : ICrawlerService
 {
-	private static readonly (string, Crawler)[] Crawlers =
-		EnumValues<Crawler>.GetValues().Select(x => (x.ToStringMistake(), x)).ToArray();
-
-	private static readonly IndexTree         CrawlerIndex = Crawlers.Select(x => x.Item1).BuildIndexTree();
-	private readonly        DetectionOptions  _options;
-	private readonly        IUserAgentService _useragent;
+	private static readonly (string, Crawler)[] Crawlers     = EnumValues<Crawler>.GetValues().Select(x => (x.ToLowerString(), x)).ToArray();
+	private static readonly IndexTree           CrawlerIndex = Crawlers.Select(x => x.Item1).BuildIndexTree();
+	private readonly        DetectionOptions    _options;
+	private readonly        IUserAgentService   _useragent;
 
 	private Crawler? _name;
 	private Version? _version;
@@ -63,14 +61,10 @@ public sealed class CrawlerService : ICrawlerService
 	}
 
 	private static bool HasOthers(string agent, IEnumerable<string> others)
-	{
-		return agent.Contains("bot", StringComparison.Ordinal)
-		       || others.Any(x => agent.Contains(x, StringComparison.Ordinal));
-	}
+		=> agent.Contains("bot", StringComparison.Ordinal) ||
+		   others.Any(x => agent.Contains(x, StringComparison.Ordinal));
 
 	private static string FindBot(string agent)
-	{
-		return agent.Split(' ')
-		            .FirstOrDefault(x => x.SearchContains(CrawlerIndex)) ?? string.Empty;
-	}
+		=> agent.Split(' ')
+		        .FirstOrDefault(x => x.SearchContains(CrawlerIndex)) ?? string.Empty;
 }

--- a/Detection/src/Services/CrawlerService.cs
+++ b/Detection/src/Services/CrawlerService.cs
@@ -8,12 +8,13 @@ namespace Wangkanai.Detection.Services;
 
 public sealed class CrawlerService : ICrawlerService
 {
-	private static readonly Dictionary<string, Crawler> Crawlers     = EnumValues<Crawler>.GetValues()
-	                                                                                      .Select(x => (x.ToLowerString(), x))
-	                                                                                      .ToDictionary(x => x.Item1, x => x.Item2);
-	private static readonly IndexTree                   CrawlerIndex = Crawlers.Select(x => x.Key).BuildIndexTree();
-	private readonly        DetectionOptions            _options;
-	private readonly        IUserAgentService           _useragent;
+	private static readonly Dictionary<string, Crawler> Crawlers = EnumValues<Crawler>.GetValues()
+	                                                                                  .Select(x => (x.ToLowerString(), x))
+	                                                                                  .ToDictionary(x => x.Item1, x => x.Item2);
+
+	private static readonly IndexTree         CrawlerIndex = Crawlers.Select(x => x.Key).BuildIndexTree();
+	private readonly        DetectionOptions  _options;
+	private readonly        IUserAgentService _useragent;
 
 	private Crawler? _name;
 	private Version? _version;
@@ -35,8 +36,9 @@ public sealed class CrawlerService : ICrawlerService
 		if (string.IsNullOrEmpty(agent))
 			return Crawler.Unknown;
 
-		foreach (var crawler in Crawlers.Where(crawler => agent.Contains(crawler.Key)))
-			return crawler.Value;
+		foreach (var crawler in Crawlers)
+			if (agent.Contains(crawler.Key))
+				return crawler.Value;
 
 		return HasOthers(agent, _options.Crawler.Others)
 			       ? Crawler.Others

--- a/Detection/src/Services/DeviceService.cs
+++ b/Detection/src/Services/DeviceService.cs
@@ -30,13 +30,13 @@ public sealed class DeviceService : IDeviceService
 			return Device.Tv;
 		if (IsMobile(agent))
 			return Device.Mobile;
-		if (agent.ContainsMistake(Device.Watch))
+		if (agent.ContainsLower(Device.Watch))
 			return Device.Watch;
-		if (agent.ContainsMistake(Device.Console))
+		if (agent.ContainsLower(Device.Console))
 			return Device.Console;
-		if (agent.ContainsMistake(Device.Car))
+		if (agent.ContainsLower(Device.Car))
 			return Device.Car;
-		if (agent.ContainsMistake(Device.IoT))
+		if (agent.ContainsLower(Device.IoT))
 			return Device.IoT;
 
 		return Device.Desktop;
@@ -55,6 +55,6 @@ public sealed class DeviceService : IDeviceService
 
 	private static bool IsTV(string agent)
 	{
-		return agent.ContainsMistake(Device.Tv) || agent.Contains("bravia", StringComparison.Ordinal);
+		return agent.ContainsLower(Device.Tv) || agent.Contains("bravia", StringComparison.Ordinal);
 	}
 }

--- a/Detection/src/Services/EngineService.cs
+++ b/Detection/src/Services/EngineService.cs
@@ -31,26 +31,26 @@ public sealed class EngineService : IEngineService
 			return Engine.Edge;
 		if (IsBlink(agent))
 			return Engine.Blink;
-		if (agent.ContainsMistake(Engine.WebKit))
+		if (agent.ContainsLower(Engine.WebKit))
 			return Engine.WebKit;
-		if (agent.ContainsMistake(Engine.Trident))
+		if (agent.ContainsLower(Engine.Trident))
 			return Engine.Trident;
-		if (agent.ContainsMistake(Engine.Gecko))
+		if (agent.ContainsLower(Engine.Gecko))
 			return Engine.Gecko;
-		if (agent.ContainsMistake(Engine.Servo))
+		if (agent.ContainsLower(Engine.Servo))
 			return Engine.Servo;
 		return Engine.Others;
 	}
 
 	private static bool IsBlink(string agent)
 	{
-		return agent.ContainsMistake(Browser.Chrome) &&
-		       agent.ContainsMistake(Engine.WebKit);
+		return agent.ContainsLower(Browser.Chrome) &&
+		       agent.ContainsLower(Engine.WebKit);
 	}
 
 	private static bool IsEdge(string agent, Platform os)
 	{
-		return agent.ContainsMistake(Engine.Edge) ||
+		return agent.ContainsLower(Engine.Edge) ||
 		       agent.Contains("edg", StringComparison.Ordinal) &&
 		       Platform.Windows.HasFlag(os);
 	}

--- a/Detection/src/Services/PlatformService.cs
+++ b/Detection/src/Services/PlatformService.cs
@@ -140,11 +140,12 @@ public sealed class PlatformService : IPlatformService
 
 	private static readonly string[]  X86DeviceList     = { "i86", "i686", Processor.x86.ToString() };
 	private static readonly IndexTree X86DeviceIndex    = X86DeviceList.BuildIndexTree();
-	private static readonly string[]  X64DeviceList     = { "x86_64", "wow64", "win64", Processor.x64.ToStringMistake() };
+	private static readonly string[]  X64DeviceList     = { "x86_64", "wow64", "win64", Processor.x64.ToLowerString() };
 	private static readonly IndexTree X64DeviceIndex    = X64DeviceList.BuildIndexTree();
-	private static readonly string[]  IosDeviceList     = { "iphone", "ipod", Platform.iOS.ToStringMistake() };
+	private static readonly string[]  IosDeviceList     = { "iphone", "ipod", Platform.iOS.ToLowerString() };
 	private static readonly IndexTree IosDeviceIndex    = IosDeviceList.BuildIndexTree();
-	private static readonly string[]  IPadosDeviceList  = { "ipad", Platform.iPadOS.ToStringMistake() };
+	private static readonly string[]  IPadosDeviceList  = { "ipad", Platform.iPadOS.ToLowerString() };
+
 	private static readonly IndexTree IPadosDeviceIndex = IPadosDeviceList.BuildIndexTree();
 	private static readonly string[]  ChromeOSList      = { "cros" };
 	private static readonly IndexTree ChromeOSIndex     = ChromeOSList.BuildIndexTree();

--- a/Detection/src/Services/PlatformService.cs
+++ b/Detection/src/Services/PlatformService.cs
@@ -33,17 +33,17 @@ public sealed class PlatformService : IPlatformService
 		if (string.IsNullOrEmpty(agent))
 			return Platform.Unknown;
 
-		if (agent.ContainsMistake(Platform.Android))
+		if (agent.ContainsLower(Platform.Android))
 			return Platform.Android;
-		if (agent.ContainsMistake(Platform.Windows))
+		if (agent.ContainsLower(Platform.Windows))
 			return Platform.Windows;
 		if (IsiPadOS(agent))
 			return Platform.iPadOS;
 		if (IsiOS(agent))
 			return Platform.iOS;
-		if (agent.ContainsMistake(Platform.Mac))
+		if (agent.ContainsLower(Platform.Mac))
 			return Platform.Mac;
-		if (agent.ContainsMistake(Platform.Linux))
+		if (agent.ContainsLower(Platform.Linux))
 			return Platform.Linux;
 		if (IsChromeOS(agent))
 			return Platform.ChromeOS;
@@ -102,13 +102,13 @@ public sealed class PlatformService : IPlatformService
 		=> agent.SearchContains(ChromeOSIndex);
 
 	private static bool IsArm(string agent, Platform os)
-		=> agent.ContainsMistake(Processor.ARM)
-		   || agent.ContainsMistake(Platform.Android)
-		   || os is Platform.iOS or Platform.iPadOS;
+		=> agent.ContainsLower(Processor.ARM) ||
+		   agent.ContainsLower(Platform.Android) ||
+		   os is Platform.iOS or Platform.iPadOS;
 
 	private static bool IsPowerPC(string agent, Platform os)
-		=> os == Platform.Mac
-		   && !agent.Contains("ppc", StringComparison.Ordinal);
+		=> os == Platform.Mac &&
+		   !agent.Contains("ppc", StringComparison.Ordinal);
 
 	#region Internal
 

--- a/System/src/Extensions/EnumExtensions.cs
+++ b/System/src/Extensions/EnumExtensions.cs
@@ -6,10 +6,10 @@ namespace Wangkanai.Extensions;
 
 public static class EnumExtensions
 {
-	[Obsolete]
-	public static string ToStringMistake<T>(this T value)
-		where T : Enum
-		=> EnumValues<T>.GetNameMistake(value).ToLowerInvariant();
+	// [Obsolete]
+	// public static string ToStringMistake<T>(this T value)
+	// 	where T : Enum
+	// 	=> EnumValues<T>.GetNameMistake(value).ToLowerInvariant();
 
 	[DebuggerStepThrough]
 	public static string ToOriginalString<T>(this T value)

--- a/System/src/Extensions/EnumExtensions.cs
+++ b/System/src/Extensions/EnumExtensions.cs
@@ -44,17 +44,17 @@ public static class EnumExtensions
 		=> value.ContainSingle(flags) ||
 		   flags.GetFlags().Any(item => value.Contains(item.ToLowerString(), StringComparison.Ordinal));
 
-	[Obsolete]
-	public static bool ContainsMistake<T>(this string value, T flags)
-		where T : Enum
-		=> value.ContainSingleMistake(flags) ||
-		   flags.GetFlags().Any(item => value.Contains(item.ToLowerString(), StringComparison.Ordinal));
+	// [Obsolete]
+	// public static bool ContainsMistake<T>(this string value, T flags)
+	// 	where T : Enum
+	// 	=> value.ContainSingleMistake(flags) ||
+	// 	   flags.GetFlags().Any(item => value.Contains(item.ToLowerString(), StringComparison.Ordinal));
 
-	[Obsolete]
-	private static bool ContainSingleMistake<T>(this string value, T flags)
-		where T : Enum
-		=> EnumValues<T>.TryGetSingleNameMistake(flags, out var name) &&
-		   value.Contains(name, StringComparison.Ordinal);
+	// [Obsolete]
+	// private static bool ContainSingleMistake<T>(this string value, T flags)
+	// 	where T : Enum
+	// 	=> EnumValues<T>.TryGetSingleNameMistake(flags, out var name) &&
+	// 	   value.Contains(name, StringComparison.Ordinal);
 
 	private static bool ContainSingle<T>(this string value, T flags)
 		where T : Enum

--- a/System/src/Extensions/EnumExtensions.cs
+++ b/System/src/Extensions/EnumExtensions.cs
@@ -58,7 +58,7 @@ public static class EnumExtensions
 
 	private static bool ContainSingle<T>(this string value, T flags)
 		where T : Enum
-		=> EnumValues<T>.TryGetSingleNameMistake(flags, out var name) &&
+		=> EnumValues<T>.TryGetSingleName(flags, out var name) &&
 		   value.Contains(name, StringComparison.Ordinal);
 
 	[DebuggerStepThrough]

--- a/System/src/Extensions/EnumValues.cs
+++ b/System/src/Extensions/EnumValues.cs
@@ -20,11 +20,11 @@ public static class EnumValues<T> where T : Enum
 	public static bool TryGetSingleName(T value, out string result)
 		=> NamesOriginal.TryGetValue(value, out result!);
 
-	[Obsolete]
-	public static string GetNameMistake(T value)
-		=> NamesMistake.TryGetValue(value, out var result)
-			   ? result
-			   : string.Join(',', value.GetFlags().Select(x => NamesMistake[x]));
+	// [Obsolete]
+	// public static string GetNameMistake(T value)
+	// 	=> NamesMistake.TryGetValue(value, out var result)
+	// 		   ? result
+	// 		   : string.Join(',', value.GetFlags().Select(x => NamesMistake[x]));
 
 	[DebuggerStepThrough]
 	public static string GetNameOriginal(T value)

--- a/System/src/Extensions/EnumValues.cs
+++ b/System/src/Extensions/EnumValues.cs
@@ -13,24 +13,14 @@ public static class EnumValues<T> where T : Enum
 		=> NamesOriginal;
 
 	[DebuggerStepThrough]
-	public static bool TryGetSingleNameMistake(T value, out string result)
-		=> NamesMistake.TryGetValue(value, out result!);
-
-	[DebuggerStepThrough]
 	public static bool TryGetSingleName(T value, out string result)
 		=> NamesOriginal.TryGetValue(value, out result!);
 
-	// [Obsolete]
-	// public static string GetNameMistake(T value)
-	// 	=> NamesMistake.TryGetValue(value, out var result)
-	// 		   ? result
-	// 		   : string.Join(',', value.GetFlags().Select(x => NamesMistake[x]));
-
 	[DebuggerStepThrough]
 	public static string GetNameOriginal(T value)
-		=> NamesOriginal.TryGetValue(value, out var result)
-			   ? result
-			   : string.Join(',', value.GetFlags().Select(x => NamesOriginal[x]));
+		=> value.GetFlags().Any()
+			   ? string.Join(',', value.GetFlags().Select(x => NamesOriginal[x]))
+			   : NamesOriginal[value];
 
 	private static T[] Values
 		=> (T[])Enum.GetValues(typeof(T));

--- a/System/src/Extensions/EnumValues.cs
+++ b/System/src/Extensions/EnumValues.cs
@@ -28,9 +28,9 @@ public static class EnumValues<T> where T : Enum
 
 	[DebuggerStepThrough]
 	public static string GetNameOriginal(T value)
-		=> value.GetFlags().Any()
-			   ? string.Join(',', value.GetFlags().Select(x => NamesOriginal[x]))
-			   : NamesOriginal[value];
+		=> NamesOriginal.TryGetValue(value, out var result)
+			   ? result
+			   : string.Join(',', value.GetFlags().Select(x => NamesOriginal[x]));
 
 	private static T[] Values
 		=> (T[])Enum.GetValues(typeof(T));


### PR DESCRIPTION
The 'ToStringMistake' method replaced with 'ToLowerString' method across the codebase in 'BrowserService.cs', 'PlatformService.cs', 'CrawlerService.cs'. Also, some parts in 'CrawlerService.cs' were simplified for efficiency. This change provides consistency and readability in naming convention and improves overall code neatness in the mentioned files. The obsolete 'ToStringMistake' method in 'EnumExtensions.cs' was also commented out.