### PR TITLE
Update version handling in BrowserService

### DIFF
--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -45,6 +45,8 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 		var agent   = userAgentService.UserAgent.ToLower();
 		var browser = Name;
 
+		if (browser == Browser.Edge && agent.Contains("EdgA", StringComparison.OrdinalIgnoreCase))
+			return GetVersionOf(agent, "edgA".ToLowerInvariant());
 		if (browser == Browser.Edge && !agent.Contains("edge", StringComparison.Ordinal))
 			return GetVersionOf(agent, "edg");
 		if (browser == Browser.Edge)
@@ -135,8 +137,8 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 	private static Version GetVersionSafariSafari(string agent)
 	{
-		var safari        = agent.Substring(agent.IndexOf("safari/", StringComparison.Ordinal) + "safari/".Length);
-		var substring     = safari.Substring(0);
+		var safari    = agent.Substring(agent.IndexOf("safari/", StringComparison.Ordinal) + "safari/".Length);
+		var substring = safari.Substring(0);
 		if (substring.Contains('.'))
 			return substring.ToVersion();
 
@@ -185,6 +187,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 	private static bool IsEdge(string agent)
 		=> agent.ContainsLower(Browser.Edge) ||
+		   agent.Contains("edgA", StringComparison.OrdinalIgnoreCase) ||
 		   agent.Contains("win64", StringComparison.Ordinal) &&
 		   agent.Contains("edg", StringComparison.Ordinal);
 

--- a/Detection/tests/Services/BrowserServiceTests.cs
+++ b/Detection/tests/Services/BrowserServiceTests.cs
@@ -91,7 +91,7 @@ public sealed class BrowserServiceTests
 	[InlineData("79.0.309.43", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.74 Safari/537.36 Edg/79.0.309.43")]
 	[InlineData("85.0.564.51", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36 Edg/85.0.564.51")]
 	[InlineData("96.0.1054.53", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, likeGecko) Chrome/96.0.4664.93 Safari/537.36 Edg/96.0.1054.53")]
-	[InlineData("120.0.0","Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/120.0.0.0")]
+	[InlineData("120.0.0.0","Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/120.0.0.0")]
 	public void Edge(string version, string agent)
 	{
 		var resolver = MockService.BrowserService(agent);


### PR DESCRIPTION
Updated the BrowserService algorithm to correctly handle the Edge browser iteration, characterized by the "EdgA" string in the user agent. Furthermore, slight alterations have been made to the GetVersionSafariSafari method, fixing the string slicing operation.

ref: #954