### PR TITLE
Remove obsolete methods from EnumExtensions

### DIFF
--- a/System/src/Extensions/EnumExtensions.cs
+++ b/System/src/Extensions/EnumExtensions.cs
@@ -6,11 +6,6 @@ namespace Wangkanai.Extensions;
 
 public static class EnumExtensions
 {
-	// [Obsolete]
-	// public static string ToStringMistake<T>(this T value)
-	// 	where T : Enum
-	// 	=> EnumValues<T>.GetNameMistake(value).ToLowerInvariant();
-
 	[DebuggerStepThrough]
 	public static string ToOriginalString<T>(this T value)
 		where T : Enum
@@ -43,18 +38,6 @@ public static class EnumExtensions
 		where T : Enum
 		=> value.ContainSingle(flags) ||
 		   flags.GetFlags().Any(item => value.Contains(item.ToLowerString(), StringComparison.Ordinal));
-
-	// [Obsolete]
-	// public static bool ContainsMistake<T>(this string value, T flags)
-	// 	where T : Enum
-	// 	=> value.ContainSingleMistake(flags) ||
-	// 	   flags.GetFlags().Any(item => value.Contains(item.ToLowerString(), StringComparison.Ordinal));
-
-	// [Obsolete]
-	// private static bool ContainSingleMistake<T>(this string value, T flags)
-	// 	where T : Enum
-	// 	=> EnumValues<T>.TryGetSingleNameMistake(flags, out var name) &&
-	// 	   value.Contains(name, StringComparison.Ordinal);
 
 	private static bool ContainSingle<T>(this string value, T flags)
 		where T : Enum


### PR DESCRIPTION
The obsolete methods ToStringMistake, ContainsMistake, and ContainSingleMistake have been removed from the EnumExtensions class. This cleanup simplifies the code and avoids the usage of deprecated functionality.