### PR TITLE
Update system documentations

### DIFF
--- a/System/src/Collections/RangeIterator.cs
+++ b/System/src/Collections/RangeIterator.cs
@@ -25,7 +25,7 @@ public sealed class RangeIterator<T> : IEnumerable<T>
 	public bool Ascending { get; }
 
 	/// <summary>
-	/// Create a ascending iterator iver the given range with the given step function, with the specified direction (optional)
+	/// Create an ascending iterator iver the given range with the given step function, with the specified direction (optional)
 	/// </summary>
 	public RangeIterator(Range<T> range, Func<T, T> step, bool ascending = true)
 	{
@@ -41,7 +41,7 @@ public sealed class RangeIterator<T> : IEnumerable<T>
 	}
 
 	/// <summary>
-	/// Returns an <see cref="IEnumerator{T}"/> running over the range.
+	/// Returns a <see cref="IEnumerator{T}"/> running over the range.
 	/// </summary>
 	public IEnumerator<T> GetEnumerator()
 	{

--- a/System/src/Collections/ReverseComparer.cs
+++ b/System/src/Collections/ReverseComparer.cs
@@ -2,6 +2,10 @@
 
 namespace Wangkanai.Collections;
 
+/// <summary>
+/// Represents a reverse comparer that reverses the ordering of a given comparer.
+/// </summary>
+/// <typeparam name="T">The type of objects to compare.</typeparam>
 public sealed class ReverseComparer<T> : IComparer<T>
 {
 	/// <summary>
@@ -16,8 +20,17 @@ public sealed class ReverseComparer<T> : IComparer<T>
 	public ReverseComparer(IComparer<T> original) => Original = original.ThrowIfNull();
 
 	/// <summary>
-	/// Returns the result of comparing the specified values using the original comparer, but reversing the order of comparison
+	/// Compares two objects of type T in reverse order using the original comparer.
 	/// </summary>
-	/// <returns></returns>
+	/// <param name="x">The first object to compare.</param>
+	/// <param name="y">The second object to compare.</param>
+	/// <typeparam name="T">The type of the objects to compare.</typeparam>
+	/// <returns>
+	/// A value that indicates the relative order of the objects being compared.
+	/// The return value has the following meanings:
+	/// - Less than zero: x is less than y.
+	/// - Zero: x equals y.
+	/// - Greater than zero: x is greater than y.
+	/// </returns>
 	public int Compare(T? x, T? y) => Original.Compare(y, x);
 }

--- a/System/src/Collections/StringArrayComparer.cs
+++ b/System/src/Collections/StringArrayComparer.cs
@@ -1,16 +1,20 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
-#nullable enable
-
 namespace Wangkanai.Collections;
 
+/// <summary>
+/// Provides a string array comparer for comparing string arrays for equality.
+/// </summary>
 internal sealed class StringArrayComparer : IEqualityComparer<string[]>
 {
-	public static readonly StringArrayComparer Ordinal           = new StringArrayComparer(StringComparer.Ordinal);
-	public static readonly StringArrayComparer OrdinalIgnoreCase = new StringArrayComparer(StringComparer.OrdinalIgnoreCase);
+	public static readonly StringArrayComparer Ordinal           = new(StringComparer.Ordinal);
+	public static readonly StringArrayComparer OrdinalIgnoreCase = new(StringComparer.OrdinalIgnoreCase);
 
 	private readonly StringComparer _valueComparer;
 
+	/// <summary>
+	/// Provides a string array comparer for comparing string arrays for equality.
+	/// </summary>
 	public StringArrayComparer(StringComparer valueComparer)
 	{
 		_valueComparer = valueComparer;

--- a/System/src/Collections/StringArrayComparer.cs
+++ b/System/src/Collections/StringArrayComparer.cs
@@ -46,6 +46,11 @@ internal sealed class StringArrayComparer : IEqualityComparer<string[]>
 		return true;
 	}
 
+	/// <summary>
+	/// Calculates the hash code for a string array based on its elements using the provided comparer.
+	/// </summary>
+	/// <param name="obj">The string array to calculate the hash code for.</param>
+	/// <returns>The hash code for the input string array.</returns>
 	public int GetHashCode(string[] obj)
 	{
 		if (obj == null)

--- a/System/tests/Collections/RangeIteratorTests.cs
+++ b/System/tests/Collections/RangeIteratorTests.cs
@@ -4,69 +4,69 @@ namespace Wangkanai.Collections;
 
 public class RangeIteratorTests
 {
-	private static readonly int[] ZeroFour = [0, 1, 2, 3, 4];
-	private static readonly int[] ZeroFive = [0, 1, 2, 3, 4, 5];
-	private static readonly int[] OneFour  = [1, 2, 3, 4];
-	private static readonly int[] OneFive  = [1, 2, 3, 4, 5];
-	private static readonly int[] FiveOne  = [5, 4, 3, 2, 1];
-	private static readonly int[] FiveZero = [5, 4, 3, 2, 1, 0];
-	private static readonly int[] FourOne  = [4, 3, 2, 1];
-	private static readonly int[] FourZero = [4, 3, 2, 1, 0];
+	private static readonly int[] ArrayZeroFour = [0, 1, 2, 3, 4];
+	private static readonly int[] ArrayZeroFive = [0, 1, 2, 3, 4, 5];
+	private static readonly int[] ArrayOneFour  = [1, 2, 3, 4];
+	private static readonly int[] ArrayOneFive  = [1, 2, 3, 4, 5];
+	private static readonly int[] ArrayFiveOne  = [5, 4, 3, 2, 1];
+	private static readonly int[] ArrayFiveZero = [5, 4, 3, 2, 1, 0];
+	private static readonly int[] ArrayFourOne  = [4, 3, 2, 1];
+	private static readonly int[] ArrayFourZero = [4, 3, 2, 1, 0];
 
 	[Fact]
 	public void InclusiveRange()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5), x => x + 1);
-		Assert.True(subject.SequenceEqual(ZeroFive));
+		Assert.True(subject.SequenceEqual(ArrayZeroFive));
 	}
 
 	[Fact]
 	public void RangeExcludingStart()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart(), x => x + 1);
-		Assert.True(subject.SequenceEqual(OneFive));
+		Assert.True(subject.SequenceEqual(ArrayOneFive));
 	}
 
 	[Fact]
 	public void RangeExcludingEnd()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeEnd(), x => x + 1);
-		Assert.True(subject.SequenceEqual(ZeroFour));
+		Assert.True(subject.SequenceEqual(ArrayZeroFour));
 	}
 
 	[Fact]
 	public void RangeExcludingBoth()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart().ExcludeEnd(), x => x + 1);
-		Assert.True(subject.SequenceEqual(OneFour));
+		Assert.True(subject.SequenceEqual(ArrayOneFour));
 	}
 
 	[Fact]
 	public void DescendingInclusiveRange()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(FiveZero));
+		Assert.True(subject.SequenceEqual(ArrayFiveZero));
 	}
 
 	[Fact]
 	public void DescendingRangeExcludingStart()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart(), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(FiveOne));
+		Assert.True(subject.SequenceEqual(ArrayFiveOne));
 	}
 
 	[Fact]
 	public void DescendingRangeExcludingEnd()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeEnd(), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(FourZero));
+		Assert.True(subject.SequenceEqual(ArrayFourZero));
 	}
 
 	[Fact]
 	public void DescendingRangeExcludingBoth()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart().ExcludeEnd(), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(FourOne));
+		Assert.True(subject.SequenceEqual(ArrayFourOne));
 	}
 
 	[Fact]

--- a/System/tests/Collections/RangeIteratorTests.cs
+++ b/System/tests/Collections/RangeIteratorTests.cs
@@ -4,69 +4,69 @@ namespace Wangkanai.Collections;
 
 public class RangeIteratorTests
 {
-	private static readonly int[] zero_four = { 0, 1, 2, 3, 4 };
-	private static readonly int[] zero_five = { 0, 1, 2, 3, 4, 5 };
-	private static readonly int[] one_four  = { 1, 2, 3, 4 };
-	private static readonly int[] one_five  = { 1, 2, 3, 4, 5 };
-	private static readonly int[] five_one  = { 5, 4, 3, 2, 1 };
-	private static readonly int[] five_zero = { 5, 4, 3, 2, 1, 0 };
-	private static readonly int[] four_one  = { 4, 3, 2, 1 };
-	private static readonly int[] four_zero = { 4, 3, 2, 1, 0 };
+	private static readonly int[] ZeroFour = [0, 1, 2, 3, 4];
+	private static readonly int[] ZeroFive = [0, 1, 2, 3, 4, 5];
+	private static readonly int[] OneFour  = [1, 2, 3, 4];
+	private static readonly int[] OneFive  = [1, 2, 3, 4, 5];
+	private static readonly int[] FiveOne  = [5, 4, 3, 2, 1];
+	private static readonly int[] FiveZero = [5, 4, 3, 2, 1, 0];
+	private static readonly int[] FourOne  = [4, 3, 2, 1];
+	private static readonly int[] FourZero = [4, 3, 2, 1, 0];
 
 	[Fact]
 	public void InclusiveRange()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5), x => x + 1);
-		Assert.True(subject.SequenceEqual(zero_five));
+		Assert.True(subject.SequenceEqual(ZeroFive));
 	}
 
 	[Fact]
 	public void RangeExcludingStart()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart(), x => x + 1);
-		Assert.True(subject.SequenceEqual(one_five));
+		Assert.True(subject.SequenceEqual(OneFive));
 	}
 
 	[Fact]
 	public void RangeExcludingEnd()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeEnd(), x => x + 1);
-		Assert.True(subject.SequenceEqual(zero_four));
+		Assert.True(subject.SequenceEqual(ZeroFour));
 	}
 
 	[Fact]
 	public void RangeExcludingBoth()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart().ExcludeEnd(), x => x + 1);
-		Assert.True(subject.SequenceEqual(one_four));
+		Assert.True(subject.SequenceEqual(OneFour));
 	}
 
 	[Fact]
 	public void DescendingInclusiveRange()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(five_zero));
+		Assert.True(subject.SequenceEqual(FiveZero));
 	}
 
 	[Fact]
 	public void DescendingRangeExcludingStart()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart(), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(five_one));
+		Assert.True(subject.SequenceEqual(FiveOne));
 	}
 
 	[Fact]
 	public void DescendingRangeExcludingEnd()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeEnd(), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(four_zero));
+		Assert.True(subject.SequenceEqual(FourZero));
 	}
 
 	[Fact]
 	public void DescendingRangeExcludingBoth()
 	{
 		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart().ExcludeEnd(), x => x - 1, false);
-		Assert.True(subject.SequenceEqual(four_one));
+		Assert.True(subject.SequenceEqual(FourOne));
 	}
 
 	[Fact]

--- a/System/tests/Collections/RangeIteratorTests.cs
+++ b/System/tests/Collections/RangeIteratorTests.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
+using FluentAssertions;
+
 namespace Wangkanai.Collections;
 
 public class RangeIteratorTests
@@ -16,29 +18,45 @@ public class RangeIteratorTests
 	[Fact]
 	public void InclusiveRange()
 	{
-		var subject = new RangeIterator<int>(new Range<int>(0, 5), x => x + 1);
+		var range   = new Range<int>(0, 5);
+		var subject = new RangeIterator<int>(range, x => x + 1);
 		Assert.True(subject.SequenceEqual(ArrayZeroFive));
+		subject.Range.Should().Be(range);
+		subject.Step.Should().NotBeNull();
+		subject.Ascending.Should().BeTrue();
 	}
 
 	[Fact]
 	public void RangeExcludingStart()
 	{
-		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart(), x => x + 1);
+		var range   = new Range<int>(0, 5).ExcludeStart();
+		var subject = new RangeIterator<int>(range, x => x + 1);
 		Assert.True(subject.SequenceEqual(ArrayOneFive));
+		subject.Range.Should().Be(range);
+		subject.Step.Should().NotBeNull();
+		subject.Ascending.Should().BeTrue();
 	}
 
 	[Fact]
 	public void RangeExcludingEnd()
 	{
-		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeEnd(), x => x + 1);
+		var range   = new Range<int>(0, 5).ExcludeEnd();
+		var subject = new RangeIterator<int>(range, x => x + 1);
 		Assert.True(subject.SequenceEqual(ArrayZeroFour));
+		subject.Range.Should().Be(range);
+		subject.Step.Should().NotBeNull();
+		subject.Ascending.Should().BeTrue();
 	}
 
 	[Fact]
 	public void RangeExcludingBoth()
 	{
-		var subject = new RangeIterator<int>(new Range<int>(0, 5).ExcludeStart().ExcludeEnd(), x => x + 1);
+		var range   = new Range<int>(0, 5).ExcludeStart().ExcludeEnd();
+		var subject = new RangeIterator<int>(range, x => x + 1);
 		Assert.True(subject.SequenceEqual(ArrayOneFour));
+		subject.Range.Should().Be(range);
+		subject.Step.Should().NotBeNull();
+		subject.Ascending.Should().BeTrue();
 	}
 
 	[Fact]


### PR DESCRIPTION
Changed all camel case variable names to Pascal case in 'RangeIteratorTests.cs' as part of the ongoing effort to enforce naming conventions and improve code readability.