### PR TITLE
Added project reference and updated version prefix

### DIFF
--- a/Hosting/Directory.Build.props
+++ b/Hosting/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>3.1.0</VersionPrefix>
+		<VersionPrefix>3.2.0</VersionPrefix>
 		<Title>Wangkanai Hosting</Title>
 		<PackageTags>aspnetcore;hosting;</PackageTags>
 		<Description>Elevate your application's configuration and runtime with `Hosting`, a .NET library that puts you in control. Streamline your setup process, enhance your application's performance, and manage your project like a pro. Whether it's for an enterprise system or a personal project, `Hosting` simplifies and supercharges your application management. Join our community, discover the art of efficient configuration, and let's redefine application runtime with Hosting.</Description>

--- a/Microservice/src/Wangkanai.Microservice.csproj
+++ b/Microservice/src/Wangkanai.Microservice.csproj
@@ -6,4 +6,8 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/sign.ps1
+++ b/sign.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 $dirs=[ordered]@{
-#    1="System";
+    1="System";
 #    2="Validation";
 #    3="Annotations";
 #    4="Extensions";


### PR DESCRIPTION
A new project reference to Wangkanai.Hosting.csproj has been added in Wangkanai.Microservice.csproj. The version prefix in Directory.Build.props has also been changed from 3.1.0 to 3.2.0. Additionally, a tweak has been made on the sign.ps1 script, specifically uncommenting the "System" directory.