### PR TITLE
Add DateTimeNow and DateTimeOffsetNow entity generators

### DIFF
--- a/EntityFramework/Directory.Build.props
+++ b/EntityFramework/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.3.0</VersionPrefix>
 		<Title>Wangkanai EntityFramework</Title>
 		<PackageTags>aspnetcore;entityframework;efcore;</PackageTags>
 		<Description>Elevate your Entity Framework experience with `EntityFramework`. A productivity powerhouse, this library comes packed with extra features and helpers to simplify your development workflow. From managing complex relationships to executing efficient queries, `EntityFramework` is your ultimate tool for data handling in ASP.NET Core.</Description>

--- a/EntityFramework/src/Generators/DateTimeNowGenerator.cs
+++ b/EntityFramework/src/Generators/DateTimeNowGenerator.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace Wangkanai.EntityFramework.Generators;
+
+public sealed class DateTimeNowGenerator : ValueGenerator<DateTime>
+{
+	public override bool GeneratesTemporaryValues => false;
+
+	public override DateTime Next(EntityEntry entry)
+	{
+		entry.ThrowIfNull();
+		return DateTime.Now;
+	}
+}

--- a/EntityFramework/src/Generators/DateTimeOffsetNowGenerator.cs
+++ b/EntityFramework/src/Generators/DateTimeOffsetNowGenerator.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+using Microsoft.EntityFrameworkCore.ChangeTracking;
+using Microsoft.EntityFrameworkCore.ValueGeneration;
+
+namespace Wangkanai.EntityFramework.Generators;
+
+public sealed class DateTimeOffsetNowGenerator : ValueGenerator<DateTimeOffset>
+{
+	public override bool GeneratesTemporaryValues => false;
+
+	public override DateTimeOffset Next(EntityEntry entry)
+	{
+		entry.ThrowIfNull();
+		return DateTimeOffset.Now;
+	}
+}

--- a/sign.ps1
+++ b/sign.ps1
@@ -6,7 +6,7 @@ param(
 )
 
 $dirs=[ordered]@{
-    1="System";
+#    1="System";
 #    2="Validation";
 #    3="Annotations";
 #    4="Extensions";


### PR DESCRIPTION
Added DateTimeNowGenerator and DateTimeOffsetNowGenerator classes in the Generators namespace to create DateTime and DateTimeOffset values when new entities are added in the EntityFramework context. These generators override Next method to throw an exception if entity is null or generate current timestamp otherwise.