### PR TITLE
Add new model classes and revise existing ones

### DIFF
--- a/Federation/src/Domain/Models/BaseResource.cs
+++ b/Federation/src/Domain/Models/BaseResource.cs
@@ -8,9 +8,9 @@ namespace Wangkanai.Federation.Models;
 /// Models the common data Api and identity resources.
 /// </summary>
 [DebuggerDisplay("{DebuggerDisplay,nq}")]
-public abstract class AbstractResource
+public abstract class BaseResource
 {
-	private string DebuggerDisplay => Name ?? $"{{{typeof(AbstractResource)}}}";
+	private string DebuggerDisplay => Name ?? $"{{{typeof(BaseResource)}}}";
 
 	/// <summary>
 	/// Indicates if this resource is enabled. Defaults to true.

--- a/Federation/src/Domain/Models/FederationClient.cs
+++ b/Federation/src/Domain/Models/FederationClient.cs
@@ -26,8 +26,8 @@ public sealed class FederationClient
 	public bool   RequireDPoP          { get; set; }
 
 
-	public  ICollection<FederationSecret> ClientSecrets    { get; set; } = new HashSet<FederationSecret>();
-	private ICollection<string>           _allowGrantTypes { get; set; } = new GrantTypeValidationHashSet();
+	public  ICollection<FederationSecret> ClientSecrets   { get; set; } = new HashSet<FederationSecret>();
+	private ICollection<string>           AllowGrantTypes { get; set; } = new GrantTypeValidationHashSet();
 
 	public ICollection<string> AllowedGrantTypes
 	{

--- a/Federation/src/Domain/Models/FederationCompany.cs
+++ b/Federation/src/Domain/Models/FederationCompany.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Federation.Models;
+
+public class FederationCompany { }

--- a/Federation/src/Domain/Models/FederationDirectory.cs
+++ b/Federation/src/Domain/Models/FederationDirectory.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Federation.Models;
+
+public class FederationDirectory { }

--- a/Federation/src/Domain/Models/FederationGroup.cs
+++ b/Federation/src/Domain/Models/FederationGroup.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Federation.Models;
+
+public class FederationGroup { }

--- a/Federation/src/Domain/Models/FederationResource.cs
+++ b/Federation/src/Domain/Models/FederationResource.cs
@@ -7,7 +7,7 @@ namespace Wangkanai.Federation.Models;
 /// <summary>
 /// Models a user federation resource.
 /// </summary>
-[DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
+[DebuggerDisplay("{DebuggerDisplay,nq}")]
 public class FederationResource : BaseResource
 {
 	private string DebuggerDisplay => Name ?? $"{{{typeof(FederationResource)}}}";
@@ -35,6 +35,12 @@ public class FederationResource : BaseResource
 	public FederationResource(string name, IEnumerable<string> claims)
 		: this(name, name, claims) { }
 
+	/// <summary>
+	/// Initializes a new instance of the <see cref="FederationResource"/> class.
+	/// </summary>
+	/// <param name="name">The name</param>
+	/// <param name="displayName">The display name</param>
+	/// <param name="claims">List of associated user claims that should be included when this resource is requested.</param>
 	public FederationResource(string name, string displayName, IEnumerable<string> claims)
 	{
 		name.ThrowIfNull();

--- a/Federation/src/Domain/Models/FederationResource.cs
+++ b/Federation/src/Domain/Models/FederationResource.cs
@@ -8,7 +8,7 @@ namespace Wangkanai.Federation.Models;
 /// Models a user federation resource.
 /// </summary>
 [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ",nq}")]
-public class FederationResource : AbstractResource
+public class FederationResource : BaseResource
 {
 	private string DebuggerDisplay => Name ?? $"{{{typeof(FederationResource)}}}";
 

--- a/Federation/src/Domain/Models/FederationTenant.cs
+++ b/Federation/src/Domain/Models/FederationTenant.cs
@@ -1,0 +1,5 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Federation.Models;
+
+public class FederationTenant { }

--- a/Federation/tests/Domain/Models/FederationClientTests.cs
+++ b/Federation/tests/Domain/Models/FederationClientTests.cs
@@ -4,5 +4,5 @@ namespace Wangkanai.Federation.Models;
 
 public class FederationClientTests
 {
-	
+
 }

--- a/Federation/tests/Domain/Models/FederationResourceTests.cs
+++ b/Federation/tests/Domain/Models/FederationResourceTests.cs
@@ -9,7 +9,16 @@ public class FederationResourceTests
 	{
 		var resource = new FederationResource();
 		Assert.NotNull(resource);
+		Assert.Null(resource.Name);
+		Assert.Null(resource.DisplayName);
+		Assert.Null(resource.Description);
+
+		Assert.True(resource.Enable);
+		Assert.False(resource.Required);
 		Assert.False(resource.Emphasize);
+		Assert.True(resource.ShowInDiscoveryDocument);
+
 		Assert.NotNull(resource.Claims);
+		Assert.NotNull(resource.Properties);
 	}
 }

--- a/Federation/tests/Domain/Models/FederationResourceTests.cs
+++ b/Federation/tests/Domain/Models/FederationResourceTests.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+
+namespace Wangkanai.Federation.Models;
+
+public class FederationResourceTests
+{
+	[Fact]
+	public void DefaultInstance()
+	{
+		var resource = new FederationResource();
+		Assert.NotNull(resource);
+		Assert.False(resource.Emphasize);
+		Assert.NotNull(resource.Claims);
+	}
+}


### PR DESCRIPTION
Several new model classes have been introduced: FederationCompany, FederationDirectory, FederationGroup, FederationTenant, and FederationResourceTests. The FederationResource and FederationClient were modified, with the former extending a renamed class from AbstractResource to BaseResource. The modification in FederationClient involves adjusting the visibility of a private property.