### PR TITLE
Refactor null checks and collection initialization.

### DIFF
--- a/Detection/src/Extensions/KmpPrefixTrie.cs
+++ b/Detection/src/Extensions/KmpPrefixTrie.cs
@@ -35,7 +35,7 @@ public class KmpPrefixTrie : IPrefixTrie
 		if (pos > 0)
 			keywords = keywords?.Where(k => k.Length > pos).ToArray();
 
-		_variants = new List<char>();
+		_variants = [];
 		if (keywords.IsNullOrEmpty()) {
 			_lookup = null;
 			_offset = 0;
@@ -86,13 +86,13 @@ public class KmpPrefixTrie : IPrefixTrie
 			{
 				seed++;
 				current = next;
-				if (next._lookup == null)
+				if (next._lookup.TrueIfNull())
 					return true;
 			}
 			else
 			{
 				current = current._fallback;
-				if (current == null)
+				if (current.TrueIfNull())
 				{
 					seed++;
 					current = this;
@@ -113,11 +113,10 @@ public class KmpPrefixTrie : IPrefixTrie
 		{
 			current = current.GetNext(source[seed]);
 
+			if (current.TrueIfNull())
+				return false;
 			if (current is {_lookup: null})
 				return true;
-
-			if (current == null)
-				return false;
 
 			seed++;
 		}
@@ -130,7 +129,7 @@ public class KmpPrefixTrie : IPrefixTrie
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private KmpPrefixTrie? GetNext(char c)
 	{
-		if (_lookup == null)
+		if (_lookup.TrueIfNull())
 			return null;
 
 		if (c - _offset < 0 || c - _offset >= _lookup.Length)
@@ -142,7 +141,7 @@ public class KmpPrefixTrie : IPrefixTrie
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private bool HasNext(char c)
 	{
-		if (_lookup == null)
+		if (_lookup.TrueIfNull())
 			return false;
 
 		if (c - _offset < 0 || c - _offset >= _lookup.Length)
@@ -151,14 +150,12 @@ public class KmpPrefixTrie : IPrefixTrie
 		return _lookup[c - _offset]?._lookup != null;
 	}
 
-	private static void BuildKmpTable(
-		KmpPrefixTrie  start, KmpPrefixTrie? nextPos = null,
-		KmpPrefixTrie? currentCnd = null)
+	private static void BuildKmpTable(KmpPrefixTrie start, KmpPrefixTrie? nextPos = null, KmpPrefixTrie?                              currentCnd = null)
 	{
-		if (nextPos == null)
+		if (nextPos.TrueIfNull())
 			return;
 
-		if (currentCnd == null)
+		if (currentCnd.TrueIfNull())
 		{
 			nextPos._fallback = null;
 			return;
@@ -172,9 +169,7 @@ public class KmpPrefixTrie : IPrefixTrie
 			var pos = nextPos;
 			var cnd = currentCnd;
 			if (cnd.HasNext(variant))
-			{
 				pos._fallback = cnd._fallback;
-			}
 			else
 			{
 				pos._fallback = cnd;

--- a/Detection/src/Extensions/KmpPrefixTrie.cs
+++ b/Detection/src/Extensions/KmpPrefixTrie.cs
@@ -9,9 +9,9 @@ namespace Wangkanai.Detection.Extensions;
 public class KmpPrefixTrie : IPrefixTrie
 {
 	private readonly KmpPrefixTrie?[]? _lookup;
-	private readonly int              _offset;
+	private readonly int               _offset;
 	private          KmpPrefixTrie?    _fallback;
-	private readonly List<char>       _variants;
+	private readonly List<char>        _variants;
 
 	/// <summary>
 	/// Creates optimized prefix Trie using static keyword list,
@@ -20,7 +20,7 @@ public class KmpPrefixTrie : IPrefixTrie
 	/// <see href="https://en.wikipedia.org/wiki/Trie"/>
 	/// </summary>
 	/// <param name="keywords">Collection of static keywords</param>
-	public KmpPrefixTrie(string[]? keywords): this(keywords, 0) { }
+	public KmpPrefixTrie(string[]? keywords) : this(keywords, 0) { }
 
 	/// <summary>
 	/// Creates optimized prefix Trie using static keyword list,
@@ -33,10 +33,12 @@ public class KmpPrefixTrie : IPrefixTrie
 	private KmpPrefixTrie(string[]? keywords, int pos)
 	{
 		if (pos > 0)
-			keywords = keywords?.Where(k => k.Length > pos).ToArray();
+			keywords = keywords?.Where(k => k.Length > pos)
+			                   .ToArray();
 
 		_variants = [];
-		if (keywords.IsNullOrEmpty()) {
+		if (keywords.IsNullOrEmpty())
+		{
 			_lookup = null;
 			_offset = 0;
 			return;
@@ -49,7 +51,7 @@ public class KmpPrefixTrie : IPrefixTrie
 		_lookup = new KmpPrefixTrie[upperBound - lowerBound + 1];
 
 		foreach (var (key, group) in keywords.GroupBy(k => k[pos])
-		                                    .Select(x => (x.Key, x)))
+		                                     .Select(x => (x.Key, x)))
 		{
 			_variants.Add(key);
 			var newKeys = group.ToArray();
@@ -75,7 +77,7 @@ public class KmpPrefixTrie : IPrefixTrie
 
 		while (length - seed > 0)
 		{
-			var           c = source[seed];
+			var            c = source[seed];
 			KmpPrefixTrie? next;
 			if (current._lookup != null && c - current._offset >= 0 && c - current._offset < current._lookup.Length)
 				next = current._lookup[c - current._offset];
@@ -115,7 +117,7 @@ public class KmpPrefixTrie : IPrefixTrie
 
 			if (current.TrueIfNull())
 				return false;
-			if (current is {_lookup: null})
+			if (current is { _lookup: null })
 				return true;
 
 			seed++;
@@ -150,7 +152,7 @@ public class KmpPrefixTrie : IPrefixTrie
 		return _lookup[c - _offset]?._lookup != null;
 	}
 
-	private static void BuildKmpTable(KmpPrefixTrie start, KmpPrefixTrie? nextPos = null, KmpPrefixTrie?                              currentCnd = null)
+	private static void BuildKmpTable(KmpPrefixTrie start, KmpPrefixTrie? nextPos = null, KmpPrefixTrie? currentCnd = null)
 	{
 		if (nextPos.TrueIfNull())
 			return;

--- a/Detection/src/Extensions/PrefixTrie.cs
+++ b/Detection/src/Extensions/PrefixTrie.cs
@@ -29,7 +29,7 @@ public readonly struct PrefixTrie : IPrefixTrie
 
 		if (keywords.IsNullOrEmpty())
 		{
-			_lookup = Array.Empty<PrefixTrie>();
+			_lookup = [];
 			_offset = 0;
 			return;
 		}

--- a/Detection/src/Extensions/PrefixTrie.cs
+++ b/Detection/src/Extensions/PrefixTrie.cs
@@ -14,7 +14,7 @@ public readonly struct PrefixTrie : IPrefixTrie
 	/// <see href="https://en.wikipedia.org/wiki/Trie"/>
 	/// </summary>
 	/// <param name="keywords">Collection of static keywords</param>
-	public PrefixTrie(string[]? keywords): this(keywords, 0) { }
+	public PrefixTrie(string[]? keywords) : this(keywords, 0) { }
 
 	/// <summary>
 	/// Creates optimized search Trie using static keyword list, uses prefix search Trie as base algorithm
@@ -25,7 +25,8 @@ public readonly struct PrefixTrie : IPrefixTrie
 	private PrefixTrie(string[]? keywords, int pos)
 	{
 		if (pos > 0)
-			keywords = keywords?.Where(k => k.Length > pos).ToArray();
+			keywords = keywords?.Where(k => k.Length > pos)
+			                   .ToArray();
 
 		if (keywords.IsNullOrEmpty())
 		{


### PR DESCRIPTION
Replaced null checks with `TrueIfNull()` for clarity and consistency. Simplified collection initialization by swapping `Array.Empty<T>()` with shorthand syntax `[]`. These changes improve code readability and maintainability.

#1025 

This pull request includes several changes to the `KmpPrefixTrie` and `PrefixTrie` classes in the `Detection/src/Extensions` directory. The primary focus of these changes is to improve code readability and consistency by replacing null checks with a new `TrueIfNull` method and simplifying array initializations.

Improvements to null checks and array initializations:

* [`Detection/src/Extensions/KmpPrefixTrie.cs`](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL89-R95): Replaced null checks with `TrueIfNull` method in multiple methods (`ContainsWithAnyIn`, `StartsWithAnyIn`, `GetNext`, `HasNext`, `BuildKmpTable`). [[1]](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL89-R95) [[2]](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bR116-L121) [[3]](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL133-R132) [[4]](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL145-R144) [[5]](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL154-R158) [[6]](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL175-L177)
* [`Detection/src/Extensions/KmpPrefixTrie.cs`](diffhunk://#diff-f7d7a6f255af7dae5d27beb7905984ef1d01f619d7228a2d6dbfecaa7549917bL38-R38): Simplified array initialization by replacing `new List<char>()` with `[]`.
* [`Detection/src/Extensions/PrefixTrie.cs`](diffhunk://#diff-cd5617ec23ae51f02e49d77655cc5a1fb2428e465490a3ffbf4183b0aff695bcL32-R32): Simplified array initialization by replacing `Array.Empty<PrefixTrie>()` with `[]`.