### PR TITLE
Update version prefixes and uncomment signing directories

### DIFF
--- a/Annotations/Directory.Build.props
+++ b/Annotations/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>0.3.0</VersionPrefix>
+		<VersionPrefix>0.2.0</VersionPrefix>
 		<Title>Wangkanai Annotations</Title>
 		<PackageTags>aspnetcore;annotations;attribute;</PackageTags>
 		<Description></Description>

--- a/Annotations/Directory.Build.props
+++ b/Annotations/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>0.1.0</VersionPrefix>
+		<VersionPrefix>0.3.0</VersionPrefix>
 		<Title>Wangkanai Annotations</Title>
 		<PackageTags>aspnetcore;annotations;attribute;</PackageTags>
 		<Description></Description>

--- a/Cryptography/Directory.Build.props
+++ b/Cryptography/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>1.1.0</VersionPrefix>
+		<VersionPrefix>1.2.0</VersionPrefix>
 		<VersionSuffix>preview1</VersionSuffix>
 		<Title>Wangkanai Cryptography</Title>
 		<PackageTags>aspnetcore;cryptography;</PackageTags>

--- a/Detection/Directory.Build.props
+++ b/Detection/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>8.14.0</VersionPrefix>
+		<VersionPrefix>8.15.0</VersionPrefix>
 		<Title>Wangkanai Detection</Title>
 		<Description>Introducing `Detection` – your gateway to understanding your users' interactions with your ASP.NET Core application. With over 10 million downloads, `Detection` offers invaluable insights into your client's device, browser, engine, and platform, even identifying crawlers. Tailor your application to your users' needs, enhance the user experience, and optimize for SEO. Discover the power of `Detection` and let's create seamless, personalized experiences for all users.</Description>
 		<PackageTags>aspnetcore;detection;</PackageTags>

--- a/Domain/Directory.Build.props
+++ b/Domain/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>4.5.0</VersionPrefix>
+		<VersionPrefix>4.6.0</VersionPrefix>
 		<Title>Wangkanai Domain</Title>
 		<PackageTags>aspnetcore;entity;domain;ddd;</PackageTags>
 		<Description>Unleash the power of Domain-Driven Design (DDD) in your .NET applications with `Domain`! This library simplifies DDD, enabling you to focus on crafting robust business logic. Whether you're an experienced DDD practitioner or a beginner, `Domain` makes DDD more accessible, helping you write better software, faster. Join our growing community, discover the extraordinary, and let's build amazing software together with `Domain`.</Description>

--- a/Extensions/Directory.Build.props
+++ b/Extensions/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>4.1.0</VersionPrefix>
+		<VersionPrefix>4.2.0</VersionPrefix>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Extensions</PackageProjectUrl>
 		<PackageNamespace>True</PackageNamespace>
 		<PackagePrimary>Internal</PackagePrimary>

--- a/Hosting/Directory.Build.props
+++ b/Hosting/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.3.0</VersionPrefix>
 		<Title>Wangkanai Hosting</Title>
 		<PackageTags>aspnetcore;hosting;</PackageTags>
 		<Description>Elevate your application's configuration and runtime with `Hosting`, a .NET library that puts you in control. Streamline your setup process, enhance your application's performance, and manage your project like a pro. Whether it's for an enterprise system or a personal project, `Hosting` simplifies and supercharges your application management. Join our community, discover the art of efficient configuration, and let's redefine application runtime with Hosting.</Description>

--- a/Mvc/Directory.Build.props
+++ b/Mvc/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.1.0</VersionPrefix>
+		<VersionPrefix>3.2.0</VersionPrefix>
 		<Title>Wangkanai Mvc</Title>
 		<Description>ASP.NET Core Mvc.</Description>
 		<PackageTags>aspnetcore;mvc;routing;infrastructure</PackageTags>

--- a/Responsive/Directory.Build.props
+++ b/Responsive/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	
 	<PropertyGroup>
-		<VersionPrefix>7.9.0</VersionPrefix>
+		<VersionPrefix>7.10.0</VersionPrefix>
 		<Title>Wangkanai Responsive</Title>
 		<PackageTags>aspnetcore;responsive;</PackageTags>
 		<Description>ASP.NET Core Responsive middleware for routing base upon request client device detection to specific view. Also in the added feature of user preference made this library even more comprehensive must for developers whom to target multiple devices with view rendered and optimized directly from the server side.</Description>

--- a/System/Directory.Build.props
+++ b/System/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>5.0.0</VersionPrefix>
+		<VersionPrefix>5.2.0</VersionPrefix>
 		<Title>Wangkanai System</Title>
 		<PackageTags>aspnetcore;sytem;runtime;</PackageTags>
 		<Description>A powerful library of extensions that unlocks the full potential of your .NET runtime. Simplify your coding process, enhance application structure, and reduce boilerplate code. Join us in pushing the boundaries of .NET, writing clean and efficient code that is robust and maintainable. Elevate your development journey with Wangkanai System!</Description>

--- a/System/Directory.Build.props
+++ b/System/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>5.2.0</VersionPrefix>
+		<VersionPrefix>5.1.0</VersionPrefix>
 		<Title>Wangkanai System</Title>
 		<PackageTags>aspnetcore;sytem;runtime;</PackageTags>
 		<Description>A powerful library of extensions that unlocks the full potential of your .NET runtime. Simplify your coding process, enhance application structure, and reduce boilerplate code. Join us in pushing the boundaries of .NET, writing clean and efficient code that is robust and maintainable. Elevate your development journey with Wangkanai System!</Description>

--- a/Testing/Directory.Build.props
+++ b/Testing/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>1.1.0</VersionPrefix>
+		<VersionPrefix>1.2.0</VersionPrefix>
 		<Title>Wangkanai Testing</Title>
 		<PackageTags>aspnetcore;testing</PackageTags>
 		<Description>This project is to turbocharge your .NET unit tests code coverage. It is a collection of helper classes and extension methods to help you write unit tests faster and easier.</Description>

--- a/Tools/Directory.Build.props
+++ b/Tools/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>2.0.0</VersionPrefix>
+		<VersionPrefix>2.1.0</VersionPrefix>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Tools</PackageProjectUrl>
 		<PackageNamespace>False</PackageNamespace>
 	</PropertyGroup>

--- a/Validation/Directory.Build.props
+++ b/Validation/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>4.1.0</VersionPrefix>
+		<VersionPrefix>4.3.0</VersionPrefix>
 		<Title>Wangkanai Validation</Title>
 		<Description>Maintain data integrity with `Validation`, a robust .NET Data Annotation library. Enforce validation rules effortlessly, ensure data accuracy, and enhance your data validation process. Try it today and revolutionize your .NET projects</Description>
 		<PackageTags>aspnetcore;validation;</PackageTags>

--- a/Webmaster/Directory.Build.props
+++ b/Webmaster/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.1.0</VersionPrefix>
+		<VersionPrefix>4.2.0</VersionPrefix>
 		<Title>Wngkanai Webmaster</Title>
 		<Description>Revolutionize your SEO with Wangkanai Webmaster. This ASP.NET Core tool boosts your site's traffic and visibility. Ideal for developers aiming to elevate their site's SEO. A must-have for enhanced web traffic, visibility, and efficiency</Description>
 		<PackageTags>aspnetcore;webmaster;seo;search;optimization;taghelper</PackageTags>

--- a/Webserver/Directory.Build.props
+++ b/Webserver/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.1.0</VersionPrefix>
+		<VersionPrefix>4.2.0</VersionPrefix>
 		<Title>Wangkanai Webserver</Title>
 		<Description>ASP.NET Core extension library that streamlines your server setup process. Simplify your configuration, make your server more resilient, and create a more enjoyable development experience. This is the tool you need to take your web development to the next level.</Description>
 		<PackageTags>aspnetcore;webserver;</PackageTags>

--- a/sign.ps1
+++ b/sign.ps1
@@ -6,9 +6,9 @@ param(
 )
 
 $dirs=[ordered]@{
-    1="System";
-    2="Validation";
-    3="Annotations";
+#    1="System";
+#    2="Validation";
+#    3="Annotations";
 #    4="Extensions";
 #    5="Testing";
 #    6="Cryptography";

--- a/sign.ps1
+++ b/sign.ps1
@@ -6,9 +6,9 @@ param(
 )
 
 $dirs=[ordered]@{
-#    1="System";
-#    2="Validation";
-#    3="Annotations";
+    1="System";
+    2="Validation";
+    3="Annotations";
 #    4="Extensions";
 #    5="Testing";
 #    6="Cryptography";


### PR DESCRIPTION
Bumped version prefixes for Validation, Annotations, and System projects to reflect new releases. Uncommented directory entries in `sign.ps1` to enable signing for System, Validation, and Annotations. These changes prepare the projects for upcoming builds and releases.