### PR TITLE
Set VersionSuffix to Beta-1 in Domain project

### DIFF
--- a/Domain/Directory.Build.props
+++ b/Domain/Directory.Build.props
@@ -2,6 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
 		<VersionPrefix>5.0.0</VersionPrefix>
+		<VersionSuffix>Beta-1</VersionSuffix>
 		<Title>Wangkanai Domain</Title>
 		<PackageTags>aspnetcore;entity;domain;ddd;</PackageTags>
 		<Description>Unleash the power of Domain-Driven Design (DDD) in your .NET applications with `Domain`! This library simplifies DDD, enabling you to focus on crafting robust business logic. Whether you're an experienced DDD practitioner or a beginner, `Domain` makes DDD more accessible, helping you write better software, faster. Join our growing community, discover the extraordinary, and let's build amazing software together with `Domain`.</Description>


### PR DESCRIPTION
### Description

This change adds the `VersionSuffix` property with the value "Beta-1" to the Domain project. This helps in identifying the release as a pre-release version and improves versioning clarity for package management systems.

### Checklist

- [ ] Code changes are properly documented.
- [ ] All tests have been updated appropriately.
- [ ] CI pipeline passes with the modifications.
- [ ] Versioning standards are adhered to where applicable.