### PR TITLE
Update workflows for code coverage output handling

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,4 +1,4 @@
-name: wangkanai-ci
+name: dotnet
 
 on:
   push:

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,4 +39,4 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Test
-      run: dotnet test  --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutput=./.qodana/code-coverage /p:CoverletOutputFormat=lcov
+      run: dotnet test  --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -39,4 +39,4 @@ jobs:
       run: dotnet build --no-restore
 
     - name: Test
-      run: dotnet test  --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage
+      run: dotnet test  --no-build --verbosity normal

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: 9.0.x
+      - name: Install npm
+        run: |
+          npm install -g rimraf
+        shell: bash
       - name: Restore dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=/.qodana/
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -36,16 +36,16 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/.qodana/ /p:MergeWith=${{ runner.temp }}/.qodana/code-coverage.info
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=/.qodana/
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/.qodana/
+          path: ${{ runner.temp }}/*/.qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:
-          args:  --apply-fixes,--save-report,--baseline,qodana.sarif.json, #--ide,QDNET,--diff-start,<GIT_START_HASH>,--diff-end,<GIT_END_HASH>
+          args: --apply-fixes,--baseline,qodana.sarif.json
           push-fixes: pull-request
           pr-mode: true
           cache-default-branch-only: false

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -37,4 +37,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ~/**/.qodana/code-coverage
+          path: ${{ runner.temp }}/**/.qodana/code-coverage

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage /p:MergeWith=${{ runner.temp }}/.qodana/coverage.json
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -19,6 +19,21 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
+      - name: Setup .NET 9.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 9.0.x
+      - name: Restore dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --no-restore
+      - name: Coverage
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage
+      - name: Archive coverage data # Archive data for use by Qodana
+        uses: actions/upload-artifact@v4
+        with:
+          name: dotnet-coverage-data
+          path: ${{ runner.temp }}/**/.qodana/code-coverage
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:
@@ -33,8 +48,4 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
-      - name: Archive coverage data # Archive data for use by Qodana
-        uses: actions/upload-artifact@v4
-        with:
-          name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/.qodana/code-coverage
+

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -19,6 +19,10 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}  # to check out the actual pull request commit, not the merge commit
           fetch-depth: 0  # a full history is required for pull request analysis
+      - name: Setup .NET 8.0
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
       - name: Setup .NET 9.0
         uses: actions/setup-dotnet@v4
         with:
@@ -26,7 +30,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --no-restore
+        run: dotnet build --no-restore --tl
       - name: Coverage
         run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage
       - name: Archive coverage data # Archive data for use by Qodana

--- a/.github/workflows/qodana_code_quality.yml
+++ b/.github/workflows/qodana_code_quality.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/code-coverage /p:MergeWith=${{ runner.temp }}/.qodana/coverage.json
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/.qodana/ /p:MergeWith=${{ runner.temp }}/.qodana/code-coverage.info
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/.qodana/code-coverage
+          path: ${{ runner.temp }}/.qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/*/.qodana/
+          path: ${{ runner.temp }}/*/.qodana/*
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -56,4 +56,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: ${{ runner.temp }}/qodana/results/qodana.sarif.json
-

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./.qodana/
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/*/.qodana/*
+          path: ${{ runner.temp }}/**/qodana/*
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:

--- a/Wangkanai.slnx
+++ b/Wangkanai.slnx
@@ -4,7 +4,7 @@
     <File Path=".github\RELEASE.yml" />
     <File Path=".github\copilot-instructions.md" />
     <File Path=".github\workflows\dotnet.yml" />
-    <File Path=".github\workflows\qodana_code_quality.yml" />
+    <File Path=".github\workflows\qodana_dotnet.yml" />
   </Folder>
   <Folder Name="/.github/ISSUE_TEMPLATE/">
     <File Path=".github\ISSUE_TEMPLATE\bug_report.md" />


### PR DESCRIPTION
Reordered Coverlet parameters in dotnet.yml for better clarity and updated the artifact path in qodana_code_quality.yml to use runner.temp for improved compatibility. These changes ensure consistent and reliable handling of coverage data.