### PR TITLE
Remove auto-fix application from Qodana workflow.

### DIFF
--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -45,7 +45,7 @@ jobs:
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:
-          args: --apply-fixes,--baseline,qodana.sarif.json
+          args: --baseline,qodana.sarif.json
           push-fixes: pull-request
           pr-mode: true
           cache-default-branch-only: false


### PR DESCRIPTION
The `--apply-fixes` argument has been removed to prevent automatic code fixes during the Qodana scan. This ensures changes are reviewed before being applied, improving workflow robustness and code quality control.