### PR TITLE
Fix artifact upload path in Qodana workflow

### DIFF
--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
+        run: dotnet test --no-build -r ${{ runner.temp }}/qodana/ /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/coverage.info
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/coverage.json
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --verbosity minimal --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity minimal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
+        run: dotnet test --no-build --verbosity minimal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/qodana/
+          path: ${{ runner.temp }}/**/qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         env:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/converage.info
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/qodana/
+          path: ${{ runner.temp }}/qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build -r ${{ runner.temp }}/qodana/ /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
+        run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -34,9 +34,9 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
       - name: Build
-        run: dotnet build --no-restore --tl
+        run: dotnet build --no-restore --verbosity minimal --tl
       - name: Coverage
-        run: dotnet test --no-build --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
+        run: dotnet test --no-build --verbosity minimal --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/coverage.json
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:
@@ -45,7 +45,7 @@ jobs:
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:
-          args: --baseline,qodana.sarif.json
+          args: --baseline,qodana.sarif.json,--linter,jetbrains/qodana-dotnet:2024.3
           push-fixes: pull-request
           pr-mode: true
           cache-default-branch-only: false

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --verbosity minimal --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity minimal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/coverage
+        run: dotnet test --no-build --verbosity minimal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/qodana/coverage
+          path: ${{ runner.temp }}/**/qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         env:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/converage.info
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/coverage.info
       - name: Archive coverage data # Archive data for use by Qodana
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/qodana/
+          path: ${{ runner.temp }}/**/qodana/*
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         env:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,12 +36,12 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --verbosity minimal --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity minimal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/
+        run: dotnet test --no-build --verbosity minimal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=./qodana/coverage
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/qodana/
+          path: ${{ runner.temp }}/**/qodana/coverage
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         env:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -48,7 +48,7 @@ jobs:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1880801860 }}
           QODANA_ENDPOINT: 'https://qodana.cloud'
         with:
-          args: --linter,jetbrains/qodana-dotnet:2024.3,--baseline,qodana.sarif.json
+          args: --baseline,qodana.sarif.json
           pr-mode: false
           push-fixes: pull-request
           cache-default-branch-only: false

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
+        run: dotnet test --no-build --collect "Code Coverage" /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
       - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -36,22 +36,22 @@ jobs:
       - name: Build
         run: dotnet build --no-restore --tl
       - name: Coverage
-        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/ /p:MergeWith=${{ runner.temp }}/qodana/
-      - name: Archive coverage data # Archive data for use by Qodana
+        run: dotnet test --no-build --verbosity normal /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=${{ runner.temp }}/qodana/
+      - name: Archive coverage data
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
           path: ${{ runner.temp }}/qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
-        with:
-          args: --baseline,qodana.sarif.json,--linter,jetbrains/qodana-dotnet:2024.3
-          push-fixes: pull-request
-          pr-mode: true
-          cache-default-branch-only: false
         env:
           QODANA_TOKEN: ${{ secrets.QODANA_TOKEN_1880801860 }}
           QODANA_ENDPOINT: 'https://qodana.cloud'
+        with:
+          args: --linter,jetbrains/qodana-dotnet:2024.3,--baseline,qodana.sarif.json
+          pr-mode: false
+          push-fixes: pull-request
+          cache-default-branch-only: false
       - name: Upload SARIF
         uses: github/codeql-action/upload-sarif@v3
         with:

--- a/.github/workflows/qodana_dotnet.yml
+++ b/.github/workflows/qodana_dotnet.yml
@@ -41,7 +41,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: dotnet-coverage-data
-          path: ${{ runner.temp }}/**/qodana/*
+          path: ${{ runner.temp }}/**/qodana/
       - name: 'Qodana Scan'
         uses: JetBrains/qodana-action@v2024.3
         with:

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -35,4 +35,9 @@
 		<PackageReference Include="FluentAssertions"/>
 	</ItemGroup>
 
+	<Target Name="SetCoverletOutputProperty" BeforeTargets="GenerateCoverageResult">
+		<PropertyGroup>
+			<CoverletOutput>$(VSTestResultsDirectory)\$(MSBuildProjectName).coverage</CoverletOutput>
+		</PropertyGroup>
+	</Target>
 </Project>

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -1,6 +1,4 @@
 version: "1.0"
-#bootstrap: curl -fsSL https://dot.net/v1/dotnet-install.sh |
-#    bash -s -- --jsonfile ./global.json -i /usr/share/dotnet
 linter: jetbrains/qodana-dotnet:2024.3
 profile:
   name: qodana.recommended


### PR DESCRIPTION
Corrected the upload-artifact path to avoid unnecessary asterisks and ensure proper coverage data upload. This change improves the reliability of the Qodana scan process.