### PR TITLE
[Detection] Fix for Incorrect Browser reported for Edge and Firefox on iOS

### DIFF
--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -34,10 +34,10 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 			return Browser.InternetExplorer;
 		if (IsGoogleSearchApp(agent))
 			return Browser.GoogleSearchApp;
+		if (IsFirefox(agent))
+			return Browser.Firefox;
 		if (agent.ContainsLower(Browser.Safari))
 			return Browser.Safari;
-		if (agent.ContainsLower(Browser.Firefox))
-			return Browser.Firefox;
 
 		return Browser.Others;
 	}
@@ -224,4 +224,8 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 	private static bool IsSamsungInternetBrowser(string agent)
 		=> agent.Contains("SamsungBrowser", StringComparison.OrdinalIgnoreCase);
+
+	private static bool IsFirefox(string agent)
+		=> agent.ContainsLower(Browser.Firefox) ||
+		   agent.Contains("FxiOS", StringComparison.OrdinalIgnoreCase);
 }

--- a/Detection/src/Services/BrowserService.cs
+++ b/Detection/src/Services/BrowserService.cs
@@ -49,6 +49,8 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 
 		if (browser == Browser.Edge && agent.Contains("EdgA", StringComparison.OrdinalIgnoreCase))
 			return GetVersionOf(agent, "edgA".ToLowerInvariant());
+		if (browser == Browser.Edge && agent.Contains("EdgiOS", StringComparison.OrdinalIgnoreCase))
+			return GetVersionOf(agent, "EdgiOS".ToLowerInvariant());
 		if (browser == Browser.Edge && !agent.Contains("edge", StringComparison.Ordinal))
 			return GetVersionOf(agent, "edg");
 		if (browser == Browser.Edge)
@@ -203,6 +205,7 @@ public sealed class BrowserService(IUserAgentService userAgentService, IEngineSe
 	private static bool IsEdge(string agent)
 		=> agent.ContainsLower(Browser.Edge) ||
 		   agent.Contains("edgA", StringComparison.OrdinalIgnoreCase) ||
+		   agent.Contains("EdgiOS", StringComparison.OrdinalIgnoreCase) ||
 		   agent.Contains("win64", StringComparison.Ordinal) &&
 		   agent.Contains("edg", StringComparison.Ordinal);
 

--- a/Detection/tests/Services/BrowserServiceTests.cs
+++ b/Detection/tests/Services/BrowserServiceTests.cs
@@ -89,6 +89,7 @@ public sealed class BrowserServiceTests
 	[InlineData("Mozilla/5.0 (Windows NT x.y; rv:10.0) Gecko/20100101 Firefox/10.0")]
 	[InlineData("Mozilla/5.0 (Windows NT 5.1; rv:11.0) Gecko Firefox/11.0 (via ggpht.com GoogleImageProxy)")]
 	[InlineData("Mozilla/5.0 (Linux arm) Gecko/20110318 Firefox/4.0b13pre Fennec/4.0")]
+	[InlineData("Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/138.0  Mobile/15E148 Safari/605.1.15")]
 	public void Firefox(string agent)
 	{
 		var resolver = MockService.BrowserService(agent);

--- a/Detection/tests/Services/BrowserServiceTests.cs
+++ b/Detection/tests/Services/BrowserServiceTests.cs
@@ -105,6 +105,7 @@ public sealed class BrowserServiceTests
 	[InlineData("85.0.564.51", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.102 Safari/537.36 Edg/85.0.564.51")]
 	[InlineData("96.0.1054.53", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, likeGecko) Chrome/96.0.4664.93 Safari/537.36 Edg/96.0.1054.53")]
 	[InlineData("120.0.0.0","Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36 EdgA/120.0.0.0")]
+	[InlineData("135.0.3179.98", "Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/135.0.3179.98 Version/18.0 Mobile/15E148 Safari/604.1")]
 	public void Edge(string version, string agent)
 	{
 		var resolver = MockService.BrowserService(agent);


### PR DESCRIPTION
While using Edge and Firefox the library incorrectly reports Browser.Safari rather then Browser.Edge and Browser.Firefox

User Agents tested with (reported from 2 of our lab-phones) 

Edge: Mozilla/5.0 (iPhone; CPU iPhone OS 18_3_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) EdgiOS/135.0.3179.98 Version/18.0 Mobile/15E148 Safari/604.1 
Firefox: Mozilla/5.0 (iPhone; CPU iPhone OS 18_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) FxiOS/138.0  Mobile/15E148 Safari/605.1.15

Fixes #1066