### PR TITLE
Set SourceLink package reference for DEBUG configuration only

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,7 +20,7 @@
 	</ItemGroup>
 
 	<!-- GitHub Source Link -->
-	<ItemGroup>
+	<ItemGroup Condition="$(Configuration) == 'DEBUG'">
 		<PackageReference Include="Microsoft.SourceLink.GitHub"/>
 	</ItemGroup>
 	<!-- xUnit Tests-->


### PR DESCRIPTION
This change restricts the Microsoft.SourceLink.GitHub package reference to the DEBUG build configuration. It ensures the package is not included in other configurations, optimizing build behavior.

#1069 Source link is appearing as a dependency