### PR TITLE
Refactor SourceLink package usage to always include PrivateAssets

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -20,8 +20,8 @@
 	</ItemGroup>
 
 	<!-- GitHub Source Link -->
-	<ItemGroup Condition="$(Configuration) == 'DEBUG'">
-		<PackageReference Include="Microsoft.SourceLink.GitHub"/>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.SourceLink.GitHub" PrivateAssets="all"/>
 	</ItemGroup>
 	<!-- xUnit Tests-->
 	<ItemGroup Condition="$(MSBuildProjectName.Contains('Tests'))">


### PR DESCRIPTION
This pull request modifies the `Directory.Build.targets` file to improve package management for the `Microsoft.SourceLink.GitHub` package. The most important change ensures that the package is included with `PrivateAssets="all"` to prevent it from being exposed as a transitive dependency.

Dependency management improvement:

* [`Directory.Build.targets`](diffhunk://#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcL23-R24): Updated the `Microsoft.SourceLink.GitHub` package reference to include the `PrivateAssets="all"` attribute, ensuring it is not exposed as a transitive dependency. Additionally, removed the condition limiting the package reference to the `DEBUG` configuration.

Reference
#1069 

Removed the DEBUG condition for the Microsoft.SourceLink.GitHub package. Added the `PrivateAssets="all"` attribute to ensure it is not exposed in consuming projects. This ensures consistent SourceLink behavior across all configurations.

