### PR TITLE
Publish nuget with private asset as all

### DIFF
--- a/System/Directory.Build.props
+++ b/System/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>5.3.0</VersionPrefix>
+		<VersionPrefix>5.4.0</VersionPrefix>
 		<Title>Wangkanai System</Title>
 		<PackageTags>aspnetcore;sytem;runtime;</PackageTags>
 		<Description>A powerful library of extensions that unlocks the full potential of your .NET runtime. Simplify your coding process, enhance application structure, and reduce boilerplate code. Join us in pushing the boundaries of .NET, writing clean and efficient code that is robust and maintainable. Elevate your development journey with Wangkanai System!</Description>


### PR DESCRIPTION
This pull request includes a version update for the `Wangkanai System` library.

Version update:

* Updated the `VersionPrefix` property in `System/Directory.Build.props` from `5.3.0` to `5.4.0`, indicating a new release version.

Bump the version prefix from 5.3.0 to 5.4.0 to align with the new release. This ensures proper versioning for the updated package.