### PR TITLE
Reduce version prefixes across all projects.

### DIFF
--- a/Analytics/Directory.Build.props
+++ b/Analytics/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>2.2.0</VersionPrefix>
+		<VersionPrefix>2.1.0</VersionPrefix>
 		<Title>Wangkanai Analytics</Title>
 		<Description>Embrace the power of data with Analytics, a .NET Core library for comprehensive website tracking. Delve into insightful statistics, understand your audience better, and make data-driven decisions with ease. From session duration to bounce rate, Analytics transforms raw data into meaningful insights. Join our community, shine a light on your website's performance, and let's unlock the full potential of website analytics with Analytics.</Description>
 		<PackageTags>aspnetcore;analytics;</PackageTags>

--- a/Annotations/Directory.Build.props
+++ b/Annotations/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>0.4.0</VersionPrefix>
+		<VersionPrefix>0.3.0</VersionPrefix>
 		<Title>Wangkanai Annotations</Title>
 		<PackageTags>csharp;annotations;attribute;</PackageTags>
 		<Description>Minimize false positive warnings, clearly specify purity and nullability in your code, handle implicit member usages, support unique API semantics in .NET, and enhance the precision of code inspections.</Description>

--- a/Blazor/Directory.Build.props
+++ b/Blazor/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.2.0</VersionPrefix>
+		<VersionPrefix>4.1.0</VersionPrefix>
 		<Title>Wangkanai Blazor</Title>
 		<Description>Wangkanai Blazor: Empowering Web UIs with Interactive Components. This project hosts a collection of carefully crafted components designed to breathe life into your Blazor applications. Our components follow common interaction patterns and adhere to the highest standards of semantic specifications, offering you reliable building blocks for your web UI.</Description>
 		<PackageTags>aspnetcore;blazor;component;grid;</PackageTags>

--- a/Cryptography/Directory.Build.props
+++ b/Cryptography/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>1.3.0</VersionPrefix>
+		<VersionPrefix>1.2.0</VersionPrefix>
 		<VersionSuffix>preview1</VersionSuffix>
 		<Title>Wangkanai Cryptography</Title>
 		<PackageTags>aspnetcore;cryptography;</PackageTags>

--- a/Detection/Directory.Build.props
+++ b/Detection/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>8.17.0</VersionPrefix>
+		<VersionPrefix>8.16.0</VersionPrefix>
 		<Title>Wangkanai Detection</Title>
 		<Description>Introducing `Detection` – your gateway to understanding your users' interactions with your ASP.NET Core application. With over 10 million downloads, `Detection` offers invaluable insights into your client's device, browser, engine, and platform, even identifying crawlers. Tailor your application to your users' needs, enhance the user experience, and optimize for SEO. Discover the power of `Detection` and let's create seamless, personalized experiences for all users.</Description>
 		<PackageTags>aspnetcore;detection;</PackageTags>

--- a/EntityFramework/Directory.Build.props
+++ b/EntityFramework/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.4.0</VersionPrefix>
+		<VersionPrefix>3.3.0</VersionPrefix>
 		<Title>Wangkanai EntityFramework</Title>
 		<PackageTags>aspnetcore;entityframework;efcore;</PackageTags>
 		<Description>Elevate your Entity Framework experience with `EntityFramework`. A productivity powerhouse, this library comes packed with extra features and helpers to simplify your development workflow. From managing complex relationships to executing efficient queries, `EntityFramework` is your ultimate tool for data handling in ASP.NET Core.</Description>

--- a/Extensions/Directory.Build.props
+++ b/Extensions/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>4.3.0</VersionPrefix>
+		<VersionPrefix>4.2.0</VersionPrefix>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Extensions</PackageProjectUrl>
 		<PackageNamespace>True</PackageNamespace>
 		<PackagePrimary>Internal</PackagePrimary>

--- a/Federation/Directory.Build.props
+++ b/Federation/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.1.0</VersionPrefix>
 		<Title>Wangkanai Federation</Title>
 		<PackageTags>aspnetcore;identity;federation;</PackageTags>
 		<Description>Take control of Authentication and Authorization in ASP.NET Core with `Federation`, your partner for seamless OAuth 2.1 and OpenID Connect integrations. From managing JWTs and external authentication providers to a comprehensive identity model structure, `Federation` offers a robust, secure, and flexible solution. Discover `Federation` and let's redefine Authentication and Authorization together.</Description>

--- a/Hosting/Directory.Build.props
+++ b/Hosting/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>3.4.0</VersionPrefix>
+		<VersionPrefix>3.3.0</VersionPrefix>
 		<Title>Wangkanai Hosting</Title>
 		<PackageTags>aspnetcore;hosting;</PackageTags>
 		<Description>Elevate your application's configuration and runtime with `Hosting`, a .NET library that puts you in control. Streamline your setup process, enhance your application's performance, and manage your project like a pro. Whether it's for an enterprise system or a personal project, `Hosting` simplifies and supercharges your application management. Join our community, discover the art of efficient configuration, and let's redefine application runtime with Hosting.</Description>

--- a/Identity/Directory.Build.props
+++ b/Identity/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.1.0</VersionPrefix>
 		<Title>Wangkanai Identity</Title>
 		<PackageTags>aspnetcore;identity;model;</PackageTags>
 		<Description>Introducing `Identity`, your essential toolkit for OpenID Connect and OAuth 2 integration in ASP.NET Core. Simplify your authentication and authorization systems with our handpicked collection of helper models. Whether for enterprise-level applications or personal projects, `Identity` offers versatility and ease-of-use. Discover Identity and take your security implementation to new heights.</Description>

--- a/Markdown/Directory.Build.props
+++ b/Markdown/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.1.0</VersionPrefix>
 		<Title>Wangkanai Markdown</Title>
 		<Description>Transform your ASP.NET Core development with `Markdown` View Engine, a tool that brings the simplicity of Markdown to your views. Say goodbye to complex HTML and Razor syntax and hello to minimalist, easy-to-write Markdown. Join the revolution and experience a new, streamlined approach to view management in ASP.NET Core.</Description>
 		<PackageTags>aspnetcore;markdown;pages</PackageTags>

--- a/Microservice/Directory.Build.props
+++ b/Microservice/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>0.2.0</VersionPrefix>
+		<VersionPrefix>0.1.0</VersionPrefix>
 		<Title>Wangkanai Microservice</Title>
 		<PackageTags>aspnetcore;microservice;webapi;</PackageTags>
 		<Description></Description>

--- a/Microservice/README.md
+++ b/Microservice/README.md
@@ -1,12 +1,12 @@
 ## Wangkanai Microservice
 
-:: Todo ::
+[![NuGet Version](https://img.shields.io/nuget/v/wangkanai.microservice)](https://www.nuget.org/packages/wangkanai.microservice)
+[![NuGet Pre Release](https://img.shields.io/nuget/vpre/wangkanai.microservice)](https://www.nuget.org/packages/wangkanai.microservice)
 
-[![NuGet Badge](https://buildstats.info/nuget/wangkanai.solver)](https://www.nuget.org/packages/wangkanai.microservice)
-[![NuGet Badge](https://buildstats.info/nuget/wangkanai.solver?includePreReleases=true)](https://www.nuget.org/packages/wangkanai.microservice)
-
-[![Build Status](https://dev.azure.com/wangkanai/GitHub/_apis/build/status/wangkanai?branchName=main)](https://dev.azure.com/wangkanai/GitHub/_build/latest?definitionId=20&branchName=main)
+[![dotnet](https://github.com/wangkanai/wangkanai/actions/workflows/dotnet.yml/badge.svg)](https://github.com/wangkanai/wangkanai/actions/workflows/dotnet.yml)
 [![Open Collective](https://img.shields.io/badge/open%20collective-support%20me-3385FF.svg)](https://opencollective.com/wangkanai)
 [![Patreon](https://img.shields.io/badge/patreon-support%20me-d9643a.svg)](https://www.patreon.com/wangkanai)
 [![GitHub](https://img.shields.io/github/license/wangkanai/wangkanai)](https://github.com/wangkanai/wangkanai/blob/main/LICENSE)
 
+Wangkanai Microservice is a lightweight framework for building scalable, resilient, and maintainable microservice applications in .NET.
+It provides a solid foundation for implementing the microservice architectural pattern with best practices and standard patterns built-in.

--- a/Mvc/Directory.Build.props
+++ b/Mvc/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.3.0</VersionPrefix>
+		<VersionPrefix>3.2.0</VersionPrefix>
 		<Title>Wangkanai Mvc</Title>
 		<Description>ASP.NET Core Mvc.</Description>
 		<PackageTags>aspnetcore;mvc;routing;infrastructure</PackageTags>

--- a/Responsive/Directory.Build.props
+++ b/Responsive/Directory.Build.props
@@ -1,23 +1,23 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
-	
+
 	<PropertyGroup>
-		<VersionPrefix>7.11.0</VersionPrefix>
+		<VersionPrefix>7.10.0</VersionPrefix>
 		<Title>Wangkanai Responsive</Title>
 		<PackageTags>aspnetcore;responsive;</PackageTags>
 		<Description>ASP.NET Core Responsive middleware for routing base upon request client device detection to specific view. Also in the added feature of user preference made this library even more comprehensive must for developers whom to target multiple devices with view rendered and optimized directly from the server side.</Description>
 		<RootNamespace>Wangkanai.Responsive</RootNamespace>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Responsive</PackageProjectUrl>
 	</PropertyGroup>
-	
+
 	<PropertyGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Responsive'">
 		<PackageIcon>wangkanai-logo.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>
-	
+
 	<ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Responsive'">
 		<None Include="..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
-	
+
 </Project>

--- a/Security/Directory.Build.props
+++ b/Security/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>3.2.0</VersionPrefix>
+		<VersionPrefix>3.1.0</VersionPrefix>
 		<Title>Wangkanai Security</Title>
 		<PackageTags>aspnetcore;security;</PackageTags>
 		<Description>Enhance your ASP.NET Core applications with Security, an extension to the native ASP.NET Core Security. This library brings advanced features for a comprehensive and proactive security solution.</Description>

--- a/Solver/Directory.Build.props
+++ b/Solver/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>2.2.0</VersionPrefix>
+		<VersionPrefix>2.1.0</VersionPrefix>
 		<Title>Wangkanai Solver</Title>
 		<PackageTags>aspnetcore;solver;optimization;simludation;scheduling;</PackageTags>
 		<Description>Embrace Wangkanai Solver, a mathematical powerhouse for handling complex optimization and simulation problems. Great for finding optimal solutions within extensive datasets, and modeling intricate systems. Join our community, contribute, and help revolutionize mathematical problem solving!</Description>

--- a/System/Directory.Build.props
+++ b/System/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>5.5.0</VersionPrefix>
+		<VersionPrefix>5.4.0</VersionPrefix>
 		<Title>Wangkanai System</Title>
 		<PackageTags>aspnetcore;sytem;runtime;</PackageTags>
 		<Description>A powerful library of extensions that unlocks the full potential of your .NET runtime. Simplify your coding process, enhance application structure, and reduce boilerplate code. Join us in pushing the boundaries of .NET, writing clean and efficient code that is robust and maintainable. Elevate your development journey with Wangkanai System!</Description>

--- a/Tabler/Directory.Build.props
+++ b/Tabler/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.2.0</VersionPrefix>
+		<VersionPrefix>4.1.0</VersionPrefix>
 		<Title>Wangkanai Tabler</Title>
 		<PackageTags>aspnetcore;blazor;tabler;</PackageTags>
 		<Description>A robust integration of the Tabler CSS framework into Blazor. Crafted for developing responsive, mobile-first, and desktop-first web applications. Enhance productivity, reduce development time, and ensure your applications look stunning on any device. Power up your Blazor projects with Tabler</Description>

--- a/Testing/Directory.Build.props
+++ b/Testing/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>1.3.0</VersionPrefix>
+		<VersionPrefix>1.2.0</VersionPrefix>
 		<Title>Wangkanai Testing</Title>
 		<PackageTags>aspnetcore;testing</PackageTags>
 		<Description>This project is to turbocharge your .NET unit tests code coverage. It is a collection of helper classes and extension methods to help you write unit tests faster and easier.</Description>

--- a/Tools/Directory.Build.props
+++ b/Tools/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>2.2.0</VersionPrefix>
+		<VersionPrefix>2.1.0</VersionPrefix>
 		<PackageProjectUrl>https://github.com/wangkanai/wangkanai/tree/main/Tools</PackageProjectUrl>
 		<PackageNamespace>False</PackageNamespace>
 	</PropertyGroup>

--- a/Validation/Directory.Build.props
+++ b/Validation/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>4.4.0</VersionPrefix>
+		<VersionPrefix>4.3.0</VersionPrefix>
 		<Title>Wangkanai Validation</Title>
 		<Description>Maintain data integrity with `Validation`, a robust .NET Data Annotation library. Enforce validation rules effortlessly, ensure data accuracy, and enhance your data validation process. Try it today and revolutionize your .NET projects</Description>
 		<PackageTags>aspnetcore;validation;</PackageTags>

--- a/Webmaster/Directory.Build.props
+++ b/Webmaster/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.3.0</VersionPrefix>
+		<VersionPrefix>4.2.0</VersionPrefix>
 		<Title>Wngkanai Webmaster</Title>
 		<Description>Revolutionize your SEO with Wangkanai Webmaster. This ASP.NET Core tool boosts your site's traffic and visibility. Ideal for developers aiming to elevate their site's SEO. A must-have for enhanced web traffic, visibility, and efficiency</Description>
 		<PackageTags>aspnetcore;webmaster;seo;search;optimization;taghelper</PackageTags>

--- a/Webserver/Directory.Build.props
+++ b/Webserver/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 
 	<PropertyGroup>
-		<VersionPrefix>4.3.0</VersionPrefix>
+		<VersionPrefix>4.2.0</VersionPrefix>
 		<Title>Wangkanai Webserver</Title>
 		<Description>ASP.NET Core extension library that streamlines your server setup process. Simplify your configuration, make your server more resilient, and create a more enjoyable development experience. This is the tool you need to take your web development to the next level.</Description>
 		<PackageTags>aspnetcore;webserver;</PackageTags>

--- a/build.ps1
+++ b/build.ps1
@@ -23,6 +23,7 @@ $dirs=[ordered]@{
     22="Tabler";
     23="Solver";
     24="Microservice";
+    25="Nation";
 }
 
 for ($i=0; $i -lt $dirs.count; $i++) {

--- a/sign.ps1
+++ b/sign.ps1
@@ -30,6 +30,7 @@ $dirs=[ordered]@{
 #    22="Tabler";
 #    23="Solver";
 #    24="Microservice";
+#    25="Nation";
 }
 
 $env:OneDriveConsumer+"\powershell-env.ps1" | out-null

--- a/sign.ps1
+++ b/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$dryrun=$false,
+    [bool]$update=$false,
     [Parameter(mandatory=$false)]
     [string]$certicate="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -93,9 +93,9 @@ for ($i=0; $i -lt $dirs.count; $i++) {
     Pop-Location;
 }
 
-if ($dryrun)
+if ($update)
 {
-    write-host "Dryrun skip version update" -ForegroundColor Yellow;
+    write-host "Skip version update" -ForegroundColor Yellow;
     exit;
 }
 


### PR DESCRIPTION
Rolled back version prefixes for multiple Wangkanai components to previous values. This ensures alignment with project versioning policies and standardizes the release management process across the repositories.

This pull request includes version downgrades across multiple modules in the Wangkanai project. The changes primarily involve reducing the `VersionPrefix` in `Directory.Build.props` files for various components, such as `Analytics`, `Blazor`, `Cryptography`, and others. These downgrades appear to align with a broader versioning strategy or rollback.

### Version Downgrades:

* **Analytics**: Downgraded `VersionPrefix` from `2.2.0` to `2.1.0` in `Analytics/Directory.Build.props`.
* **Blazor**: Downgraded `VersionPrefix` from `4.2.0` to `4.1.0` in `Blazor/Directory.Build.props`.
* **Cryptography**: Downgraded `VersionPrefix` from `1.3.0` to `1.2.0` in `Cryptography/Directory.Build.props`.
* **Detection**: Downgraded `VersionPrefix` from `8.17.0` to `8.16.0` in `Detection/Directory.Build.props`.
* **EntityFramework**: Downgraded `VersionPrefix` from `3.4.0` to `3.3.0` in `EntityFramework/Directory.Build.props`.

These changes are consistent across other modules such as `Extensions`, `Hosting`, `Identity`, `Markdown`, `Microservice`, `Mvc`, `Responsive`, `Security`, `Solver`, `System`, `Tabler`, `Testing`, and `Tools`, all reflecting similar version downgrades. For a complete list of changes, refer to the encoded references provided.