### PR TITLE
Normalize project file formatting and update project references

### DIFF
--- a/Analytics/src/Wangkanai.Analytics.csproj
+++ b/Analytics/src/Wangkanai.Analytics.csproj
@@ -5,6 +5,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Detection\src\Wangkanai.Detection.csproj" />
     </ItemGroup>
 </Project>

--- a/Analytics/tests/Wangkanai.Analytics.Tests.csproj
+++ b/Analytics/tests/Wangkanai.Analytics.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Testing\src\Wangkanai.Testing.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Testing\src\Wangkanai.Testing.csproj" />
         <ProjectReference Include="..\src\Wangkanai.Analytics.csproj" />
     </ItemGroup>
 

--- a/Blazor/benchmark/Wangkanai.Blazor.Benchmark.csproj
+++ b/Blazor/benchmark/Wangkanai.Blazor.Benchmark.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-        <ProjectReference Include="..\src\Core\Wangkanai.Blazor.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\src\Core\Wangkanai.Blazor.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Blazor/src/Components/Wangkanai.Blazor.Components.csproj
+++ b/Blazor/src/Components/Wangkanai.Blazor.Components.csproj
@@ -1,20 +1,20 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
+	<PropertyGroup>
 		<RootNamespace>Wangkanai.Blazor</RootNamespace>
-        <IsTrimmable>true</IsTrimmable>
-        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-        <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+		<IsTrimmable>true</IsTrimmable>
+		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+		<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+		<IsPackable>false</IsPackable>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" LinkBase="Shared" />
-        <Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
-    </ItemGroup>
+	<ItemGroup>
+		<Compile Include="$(SharedSourceRoot)QueryStringEnumerable.cs" LinkBase="Shared" />
+		<Compile Include="$(SharedSourceRoot)LinkerFlags.cs" LinkBase="Shared" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components" />
+	</ItemGroup>
 
 </Project>

--- a/Blazor/src/Core/Wangkanai.Blazor.csproj
+++ b/Blazor/src/Core/Wangkanai.Blazor.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <IsTrimmable>true</IsTrimmable>
-        <Optimize>true</Optimize>
-    </PropertyGroup>
+	<PropertyGroup>
+		<IsTrimmable>true</IsTrimmable>
+		<Optimize>true</Optimize>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\Validation\src\Wangkanai.Validation.csproj"/>
-
-		<ProjectReference Include="..\Components\Wangkanai.Blazor.Components.csproj" PrivateAssets="all"/>
-        <ProjectReference Include="..\Web\Wangkanai.Blazor.Components.Web.csproj" PrivateAssets="all"/>
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="$(RepoRoot)\Validation\src\Wangkanai.Validation.csproj" />
+		<ProjectReference Include="..\Components\Wangkanai.Blazor.Components.csproj" PrivateAssets="all" />
+		<ProjectReference Include="..\Web\Wangkanai.Blazor.Components.Web.csproj" PrivateAssets="all" />
+	</ItemGroup>
 
 </Project>

--- a/Blazor/src/Web/Wangkanai.Blazor.Components.Web.csproj
+++ b/Blazor/src/Web/Wangkanai.Blazor.Components.Web.csproj
@@ -1,34 +1,34 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
 
-    <PropertyGroup>
-        <IsPackable>false</IsPackable>
+	<PropertyGroup>
+		<IsPackable>false</IsPackable>
 		<RootNamespace>Wangkanai.Blazor</RootNamespace>
-    </PropertyGroup>
+	</PropertyGroup>
 
-    <ItemGroup>
-        <SupportedPlatform Include="browser"/>
-    </ItemGroup>
+	<ItemGroup>
+		<SupportedPlatform Include="browser" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.Web" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Microsoft.AspNetCore.Components.Web" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\..\Validation\src\Wangkanai.Validation.csproj"/>
-        <ProjectReference Include="..\Components\Wangkanai.Blazor.Components.csproj" PrivateAssets="all"/>
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="$(RepoRoot)\Validation\src\Wangkanai.Validation.csproj" />
+		<ProjectReference Include="..\Components\Wangkanai.Blazor.Components.csproj" PrivateAssets="all" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <Content Remove="wwwroot\**"/>
-        <Content Include="wwwroot\**"/>
-    </ItemGroup>
+	<ItemGroup>
+		<Content Remove="wwwroot\**" />
+		<Content Include="wwwroot\**" />
+	</ItemGroup>
 
-    <ItemGroup>
-        <Content Remove="package.json;package-lock.json"/>
-        <None Include="package.json">
-            <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
-            <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-        </None>
-    </ItemGroup>
+	<ItemGroup>
+		<Content Remove="package.json;package-lock.json" />
+		<None Include="package.json">
+			<ExcludeFromSingleFile>true</ExcludeFromSingleFile>
+			<CopyToOutputDirectory>Never</CopyToOutputDirectory>
+		</None>
+	</ItemGroup>
 
 </Project>

--- a/Blazor/tests/Wangkanai.Blazor.Tests.csproj
+++ b/Blazor/tests/Wangkanai.Blazor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <ItemGroup>
-        <ProjectReference Include="..\src\Core\Wangkanai.Blazor.csproj"/>
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\src\Core\Wangkanai.Blazor.csproj" />
+	</ItemGroup>
 
 </Project>

--- a/Cryptography/benchmark/Wangkanai.Cryptography.Benchmark.csproj
+++ b/Cryptography/benchmark/Wangkanai.Cryptography.Benchmark.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-	  <ProjectReference Include="..\src\Wangkanai.Cryptography.csproj" />
+		<ProjectReference Include="..\src\Wangkanai.Cryptography.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Cryptography/src/Wangkanai.Cryptography.csproj
+++ b/Cryptography/src/Wangkanai.Cryptography.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+	  <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Cryptography/tests/Wangkanai.Cryptography.Tests.csproj
+++ b/Cryptography/tests/Wangkanai.Cryptography.Tests.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<ItemGroup>
-	  <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
-	  <ProjectReference Include="..\src\Wangkanai.Cryptography.csproj" />
+		<ProjectReference Include="..\src\Wangkanai.Cryptography.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Detection/benchmark/Wangkanai.Detection.Benchmark.csproj
+++ b/Detection/benchmark/Wangkanai.Detection.Benchmark.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <ItemGroup>
-        <ProjectReference Include="..\src\Wangkanai.Detection.csproj"/>
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\src\Wangkanai.Detection.csproj" />
+	</ItemGroup>
 </Project>

--- a/Detection/src/Wangkanai.Detection.csproj
+++ b/Detection/src/Wangkanai.Detection.csproj
@@ -3,7 +3,7 @@
 		<FrameworkReference Include="Microsoft.AspNetCore.App" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj" />
-		<ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+		<ProjectReference Include="$(RepoRoot)\Hosting\src\Wangkanai.Hosting.csproj" />
+		<ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
 	</ItemGroup>
 </Project>

--- a/Domain/src/Wangkanai.Domain.csproj
+++ b/Domain/src/Wangkanai.Domain.csproj
@@ -6,6 +6,6 @@
 		<PackageReference Include="Microsoft.Extensions.Identity.Stores" />
 	</ItemGroup>
 	<ItemGroup>
-		<ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+		<ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
 	</ItemGroup>
 </Project>

--- a/EntityFramework/src/Wangkanai.EntityFramework.csproj
+++ b/EntityFramework/src/Wangkanai.EntityFramework.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Extensions/Internal/src/Wangkanai.Extensions.Internal.csproj
+++ b/Extensions/Internal/src/Wangkanai.Extensions.Internal.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\System\src\Wangkanai.System.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj"/>
     </ItemGroup>
 
 </Project>

--- a/Federation/src/AspNetIdentity/Wangkanai.Federation.AspNetIdentity.csproj
+++ b/Federation/src/AspNetIdentity/Wangkanai.Federation.AspNetIdentity.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\Identity\src\Wangkanai.Identity.csproj" />
-        <ProjectReference Include="..\..\..\Webserver\src\Wangkanai.Webserver.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Identity\src\Wangkanai.Identity.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Webserver\src\Wangkanai.Webserver.csproj" />
         <ProjectReference Include="..\Federation\Wangkanai.Federation.csproj" />
     </ItemGroup>
 

--- a/Federation/src/Domain/Wangkanai.Federation.Domain.csproj
+++ b/Federation/src/Domain/Wangkanai.Federation.Domain.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\Identity\src\Wangkanai.Identity.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Identity\src\Wangkanai.Identity.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Federation/src/Federation/Wangkanai.Federation.csproj
+++ b/Federation/src/Federation/Wangkanai.Federation.csproj
@@ -15,9 +15,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\Cryptography\src\Wangkanai.Cryptography.csproj" />
-		<ProjectReference Include="..\..\..\System\src\Wangkanai.System.csproj" />
-		<ProjectReference Include="..\..\..\Webserver\src\Wangkanai.Webserver.csproj" />
+		<ProjectReference Include="$(RepoRoot)\Cryptography\src\Wangkanai.Cryptography.csproj" />
+		<ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
+		<ProjectReference Include="$(RepoRoot)\Webserver\src\Wangkanai.Webserver.csproj" />
 		<ProjectReference Include="..\Domain\Wangkanai.Federation.Domain.csproj" />
 	</ItemGroup>
 

--- a/Hosting/src/Wangkanai.Hosting.csproj
+++ b/Hosting/src/Wangkanai.Hosting.csproj
@@ -6,6 +6,6 @@
         <FrameworkReference Include="Microsoft.AspNetCore.App" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
     </ItemGroup>
 </Project>

--- a/Identity/src/Wangkanai.Identity.csproj
+++ b/Identity/src/Wangkanai.Identity.csproj
@@ -5,7 +5,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Domain\src\Wangkanai.Domain.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Domain\src\Wangkanai.Domain.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Markdown/src/Wangkanai.Markdown.csproj
+++ b/Markdown/src/Wangkanai.Markdown.csproj
@@ -5,8 +5,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj" />
-        <ProjectReference Include="..\..\Mvc\src\Wangkanai.Mvc.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Detection\src\Wangkanai.Detection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Mvc\src\Wangkanai.Mvc.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Microservice/src/Wangkanai.Microservice.csproj
+++ b/Microservice/src/Wangkanai.Microservice.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj" />
+    <ProjectReference Include="$(RepoRoot)\Hosting\src\Wangkanai.Hosting.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Mvc/src/Wangkanai.Mvc.csproj
+++ b/Mvc/src/Wangkanai.Mvc.csproj
@@ -5,8 +5,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Extensions\Internal\src\Wangkanai.Extensions.Internal.csproj" />
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Extensions\Internal\src\Wangkanai.Extensions.Internal.csproj" />
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Nation/src/Wangkanai.Nation.csproj
+++ b/Nation/src/Wangkanai.Nation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <ProjectReference Include="..\..\Domain\src\Wangkanai.Domain.csproj" />
+    <ProjectReference Include="$(RepoRoot)\Domain\src\Wangkanai.Domain.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Responsive/src/Wangkanai.Responsive.csproj
+++ b/Responsive/src/Wangkanai.Responsive.csproj
@@ -5,7 +5,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj"/>
+		<ProjectReference Include="$(RepoRoot)\Detection\src\Wangkanai.Detection.csproj"/>
 	</ItemGroup>
 
 </Project>

--- a/Responsive/tests/Wangkanai.Responsive.Tests.csproj
+++ b/Responsive/tests/Wangkanai.Responsive.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Testing\src\Wangkanai.Testing.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Testing\src\Wangkanai.Testing.csproj" />
         <ProjectReference Include="..\src\Wangkanai.Responsive.csproj" />
     </ItemGroup>
 

--- a/Security/src/Core/Wangkanai.Security.Core.csproj
+++ b/Security/src/Core/Wangkanai.Security.Core.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\System\src\Wangkanai.System.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/Security/tests/Security/Wangkanai.Security.Tests.csproj
+++ b/Security/tests/Security/Wangkanai.Security.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <ItemGroup>
-        <ProjectReference Include="..\..\src\Authentication\Wangkanai.Security.Authentication.csproj"/>
-        <ProjectReference Include="..\..\src\Authorization\Wangkanai.Security.Authorization.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\src\Authentication\Wangkanai.Security.Authentication.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\src\Authorization\Wangkanai.Security.Authorization.csproj"/>
     </ItemGroup>
 </Project>

--- a/Solver/src/Wangkanai.Solver.csproj
+++ b/Solver/src/Wangkanai.Solver.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Tabler/benchmark/Wangkanai.Tabler.Benchmark.csproj
+++ b/Tabler/benchmark/Wangkanai.Tabler.Benchmark.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Blazor\src\Components\Wangkanai.Blazor.Components.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Blazor\src\Components\Wangkanai.Blazor.Components.csproj" />
         <ProjectReference Include="..\src\Core\Wangkanai.Tabler.csproj" />
     </ItemGroup>
 

--- a/Tabler/src/Core/Wangkanai.Tabler.csproj
+++ b/Tabler/src/Core/Wangkanai.Tabler.csproj
@@ -5,8 +5,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\..\Validation\src\Wangkanai.Validation.csproj" />
-		<!-- <ProjectReference Include="..\..\..\Blazor\src\Core\Wangkanai.Blazor.csproj" />-->
+        <ProjectReference Include="$(RepoRoot)\Validation\src\Wangkanai.Validation.csproj" />
+		<!-- <ProjectReference Include="$(RepoRoot)\Blazor\src\Core\Wangkanai.Blazor.csproj" />-->
 
         <ProjectReference Include="..\Components\Wangkanai.Tabler.Components.csproj" PrivateAssets="all" />
         <ProjectReference Include="..\Web\Wangkanai.Tabler.Components.Web.csproj" PrivateAssets="all" />

--- a/Testing/src/Wangkanai.Testing.csproj
+++ b/Testing/src/Wangkanai.Testing.csproj
@@ -23,7 +23,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+		<ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/Tools/MSBuild/src/Wangkanai.MSBuild.csproj
+++ b/Tools/MSBuild/src/Wangkanai.MSBuild.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\System\src\Wangkanai.System.csproj" />
+		<ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
 	</ItemGroup>
 </Project>

--- a/Tools/Watcher/src/Wangkanai.Watcher.csproj
+++ b/Tools/Watcher/src/Wangkanai.Watcher.csproj
@@ -1,5 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
 	<ItemGroup>
-		<ProjectReference Include="..\..\..\System\src\Wangkanai.System.csproj" />
+		<ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
 	</ItemGroup>
 </Project>

--- a/Validation/src/Wangkanai.Validation.csproj
+++ b/Validation/src/Wangkanai.Validation.csproj
@@ -5,6 +5,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj"/>
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj"/>
     </ItemGroup>
 </Project>

--- a/Webmaster/src/Wangkanai.Webmaster.csproj
+++ b/Webmaster/src/Wangkanai.Webmaster.csproj
@@ -5,13 +5,13 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Cryptography\src\Wangkanai.Cryptography.csproj" />
-        <ProjectReference Include="..\..\Detection\src\Wangkanai.Detection.csproj" />
-        <ProjectReference Include="..\..\Extensions\FileProviders\src\Wangkanai.Extensions.FileProviders.csproj" />
-        <ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj" />
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
-        <ProjectReference Include="..\..\Validation\src\Wangkanai.Validation.csproj" />
-        <ProjectReference Include="..\..\Webserver\src\Wangkanai.Webserver.csproj" />
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Detection\src\Wangkanai.Detection.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Extensions\FileProviders\src\Wangkanai.Extensions.FileProviders.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Hosting\src\Wangkanai.Hosting.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Validation\src\Wangkanai.Validation.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Cryptography\src\Wangkanai.Cryptography.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Webserver\src\Wangkanai.Webserver.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Webmaster/tests/Wangkanai.Webmaster.Tests.csproj
+++ b/Webmaster/tests/Wangkanai.Webmaster.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Testing\src\Wangkanai.Testing.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Testing\src\Wangkanai.Testing.csproj" />
         <ProjectReference Include="..\src\Wangkanai.Webmaster.csproj" />
     </ItemGroup>
 

--- a/Webserver/src/Wangkanai.Webserver.csproj
+++ b/Webserver/src/Wangkanai.Webserver.csproj
@@ -5,8 +5,8 @@
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\..\Hosting\src\Wangkanai.Hosting.csproj" />
-        <ProjectReference Include="..\..\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\System\src\Wangkanai.System.csproj" />
+        <ProjectReference Include="$(RepoRoot)\Hosting\src\Wangkanai.Hosting.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates project references across multiple `.csproj` files to use the `$(RepoRoot)` variable for specifying paths. This change standardizes the way project references are defined, improving maintainability and consistency.

### Standardization of project references:

* [`Analytics/src/Wangkanai.Analytics.csproj`](diffhunk://#diff-e9820e43c6b1d6e9503120c95fb31d88beb19afab1a264c0417513f8d08d2bddL8-R8): Updated the project reference for `Wangkanai.Detection.csproj` to use the `$(RepoRoot)` variable.
* [`Analytics/tests/Wangkanai.Analytics.Tests.csproj`](diffhunk://#diff-1c1f14c5eb054ea700785ea511bd3db0cb0642040eb8043bf7c41a0b3d026980L4-R4): Updated the project reference for `Wangkanai.Testing.csproj` to use the `$(RepoRoot)` variable.
* [`Blazor/src/Core/Wangkanai.Blazor.csproj`](diffhunk://#diff-847c4fde40b5a53886322d14cd6d5ba16c52937d153a83056d1ef7baaf9abc96L9-R9): Updated the project reference for `Wangkanai.Validation.csproj` to use the `$(RepoRoot)` variable and removed a redundant empty line.
* [`Blazor/src/Web/Wangkanai.Blazor.Components.Web.csproj`](diffhunk://#diff-4a57e4feacc190bc550e6efe2565d539deafe694eba356003a69e601b644eb7cL17-R17): Updated the project reference for `Wangkanai.Validation.csproj` to use the `$(RepoRoot)` variable.

Standardized indentation across all project files for consistency. Updated some project references to use `$(RepoRoot)` for better path resolution. These changes improve code readability and maintainability.