### PR TITLE
Update VersionSuffix to Beta-4 in Domain build props

### DIFF
--- a/Domain/Directory.Build.props
+++ b/Domain/Directory.Build.props
@@ -2,7 +2,7 @@
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
 		<VersionPrefix>5.0.0</VersionPrefix>
-		<VersionSuffix>Beta-3</VersionSuffix>
+		<VersionSuffix>Beta-4</VersionSuffix>
 		<Title>Wangkanai Domain</Title>
 		<PackageTags>aspnetcore;entity;domain;ddd;</PackageTags>
 		<Description>Unleash the power of Domain-Driven Design (DDD) in your .NET applications with `Domain`! This library simplifies DDD, enabling you to focus on crafting robust business logic. Whether you're an experienced DDD practitioner or a beginner, `Domain` makes DDD more accessible, helping you write better software, faster. Join our growing community, discover the extraordinary, and let's build amazing software together with `Domain`.</Description>


### PR DESCRIPTION
Updated the VersionSuffix property in Directory.Build.props from Beta-3 to Beta-4 to reflect the new pre-release iteration. This ensures proper versioning semantics for the project.