### PR TITLE
Add skip parameter to bypass version update

### DIFF
--- a/Analytics/sign.ps1
+++ b/Analytics/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Analytics" -ForegroundColor Yellow;
     exit;

--- a/Annotations/sign.ps1
+++ b/Annotations/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Domain" -ForegroundColor Yellow;
     exit;

--- a/Blazor/sign.ps1
+++ b/Blazor/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\Core\ -c Release -tl -o .\artifacts --include-symbols -p:Symbo
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Blazor" -ForegroundColor Yellow;
     exit;

--- a/Cryptography/sign.ps1
+++ b/Cryptography/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Cryptography" -ForegroundColor Yellow;
     exit;

--- a/Detection/sign.ps1
+++ b/Detection/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Detection" -ForegroundColor Yellow;
     exit;

--- a/Domain/sign.ps1
+++ b/Domain/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -25,7 +25,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Domain" -ForegroundColor Yellow;
     exit;

--- a/EntityFramework/sign.ps1
+++ b/EntityFramework/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: EntityFramework" -ForegroundColor Yellow;
     exit;

--- a/Extensions/sign.ps1
+++ b/Extensions/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -39,7 +39,7 @@ get-childitem .\ -directory | where { $_.Name -ne 'signed' } | where { $_.Name -
     pop-location
 }
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Extensions" -ForegroundColor Yellow;
     exit;

--- a/Federation/sign.ps1
+++ b/Federation/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack Federation.slnf -c Release -tl -o .\artifacts --include-symbols -p:S
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Federation" -ForegroundColor Yellow;
     exit;

--- a/Hosting/sign.ps1
+++ b/Hosting/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if ($update)
+if ($publish)
 {
     write-host "Skip update: Hosting" -ForegroundColor Yellow;
     exit;

--- a/Identity/sign.ps1
+++ b/Identity/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if ($update)
+if ($publish)
 {
     write-host "Skip update: Identity" -ForegroundColor Yellow;
     exit;

--- a/Markdown/sign.ps1
+++ b/Markdown/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Markdown" -ForegroundColor Yellow;
     exit;

--- a/Microservice/sign.ps1
+++ b/Microservice/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Domain" -ForegroundColor Yellow;
     exit;

--- a/Mvc/sign.ps1
+++ b/Mvc/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Mvc" -ForegroundColor Yellow;
     exit;

--- a/Nation/sign.ps1
+++ b/Nation/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -25,7 +25,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Domain" -ForegroundColor Yellow;
     exit;

--- a/Responsive/sign.ps1
+++ b/Responsive/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Responsive" -ForegroundColor Yellow;
     exit;

--- a/Security/sign.ps1
+++ b/Security/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack Security.slnf -c Release -tl -o .\artifacts --include-symbols -p:Sym
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Security" -ForegroundColor Yellow;
     exit;

--- a/Solver/sign.ps1
+++ b/Solver/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Solver" -ForegroundColor Yellow;
     exit;

--- a/System/sign.ps1
+++ b/System/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -24,7 +24,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: System" -ForegroundColor Yellow;
     exit;

--- a/Tabler/sign.ps1
+++ b/Tabler/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\Core\ -c Release -tl -o .\artifacts --include-symbols -p:Symbo
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Tabler" -ForegroundColor Yellow;
     exit;

--- a/Testing/sign.ps1
+++ b/Testing/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Testing" -ForegroundColor Yellow;
     exit;

--- a/Tools/sign.ps1
+++ b/Tools/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -39,7 +39,7 @@ get-childitem .\ -directory | where { $_.Name -ne 'signed' } | where { $_.Name -
     pop-location
 }
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Extensions" -ForegroundColor Yellow;
     exit;

--- a/Validation/sign.ps1
+++ b/Validation/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Validation" -ForegroundColor Yellow;
     exit;

--- a/Webmaster/sign.ps1
+++ b/Webmaster/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Webmaster" -ForegroundColor Yellow;
     exit;

--- a/Webserver/sign.ps1
+++ b/Webserver/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$false,
     [Parameter(mandatory=$false)]
     [string]$name="Open Source Developer, Sarin Na Wangkanai"
 )
@@ -23,7 +23,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if (!$update)
+if (!$publish)
 {
     write-host "Skip update: Webserver" -ForegroundColor Yellow;
     exit;

--- a/sign.ps1
+++ b/sign.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(mandatory=$false)]
-    [bool]$update=$false,
+    [bool]$publish=$true,
     [Parameter(mandatory=$false)]
     [bool]$skip=$false,
     [Parameter(mandatory=$false)]
@@ -79,7 +79,7 @@ for ($i=0; $i -lt $dirs.count; $i++) {
         if ($latest -ne $version)
         {
             Write-Host $latest " < " $version " Update" -ForegroundColor Green;
-            .\sign.ps1 -update $update -name $certicate
+            .\sign.ps1 -publish $publish -name $certicate
         }
         else
         {
@@ -89,7 +89,7 @@ for ($i=0; $i -lt $dirs.count; $i++) {
     catch
     {
         Write-Host "New " $latest -ForegroundColor Blue;
-        .\sign.ps1 -update $update -name $certicate
+        .\sign.ps1 -publish $publish -name $certicate
     }
 
     Pop-Location;

--- a/sign.ps1
+++ b/sign.ps1
@@ -2,6 +2,8 @@ param(
     [Parameter(mandatory=$false)]
     [bool]$update=$false,
     [Parameter(mandatory=$false)]
+    [bool]$skip=$false,
+    [Parameter(mandatory=$false)]
     [string]$certicate="Open Source Developer, Sarin Na Wangkanai"
 )
 
@@ -93,7 +95,7 @@ for ($i=0; $i -lt $dirs.count; $i++) {
     Pop-Location;
 }
 
-if (!$update)
+if ($skip)
 {
     write-host "Skip version update" -ForegroundColor Yellow;
     exit;


### PR DESCRIPTION
Introduced a new `$skip` parameter to allow skipping version updates. Updated logic to check for `$skip` instead of `$update` when deciding to skip version changes. This enhances flexibility in the script's usage.

This pull request introduces a new `skip` parameter to the `sign.ps1` script, allowing users to bypass version updates. The changes include adding the parameter and modifying the logic to handle it.

### Key Changes:

**New Parameter Addition:**
* Added a `[bool]$skip` parameter to the `sign.ps1` script to provide an option for skipping version updates.

**Logic Update:**
* Replaced the condition checking for `!$update` with `$skip` to implement the new skip functionality. When `$skip` is true, the script outputs a message and exits without performing a version update.