### PR TITLE
Update version prefix to 0.1.0

### DIFF
--- a/Nation/Directory.Build.props
+++ b/Nation/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>0.0.0</VersionPrefix>
+		<VersionPrefix>0.1.0</VersionPrefix>
 		<Title>Wangkanai Nation</Title>
 		<PackageTags>nation;country;entity;domain;ddd;</PackageTags>
 		<Description>Nation: Seed your dataset with actual country data</Description>


### PR DESCRIPTION
Incremented the version prefix from 0.0.0 to 0.1.0 in Directory.Build.props. This reflects progress towards a new release and aligns with ongoing development updates.