### PR TITLE
[Domain] AuditTrail Context Extensions

### DIFF
--- a/Domain/src/Extensions/AuditTrailContextExtensions.cs
+++ b/Domain/src/Extensions/AuditTrailContextExtensions.cs
@@ -1,0 +1,16 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+using Wangkanai.Domain.Configurations;
+
+namespace Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+public static class AuditTrailContextExtensions
+{
+	public static void ApplyAuditTrailConfiguration<TKey, TUserKey, TUserType>(this ModelBuilder builder)
+		where TKey : IEquatable<TKey>, IComparable<TKey>
+		where TUserType : IdentityUser<TUserKey>
+		where TUserKey : IEquatable<TUserKey>, IComparable<TUserKey>
+	{
+		builder.ApplyConfiguration(new AuditTrailConfiguration<TKey, TUserKey, TUserType>());
+	}
+}

--- a/Domain/tests/Extensions/AuditTrailContextExtensionsTests.cs
+++ b/Domain/tests/Extensions/AuditTrailContextExtensionsTests.cs
@@ -1,0 +1,57 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using Moq;
+using Wangkanai.Domain.Configurations;
+
+namespace Wangkanai.Domain.Extensions;
+
+public class AuditTrailContextExtensionsTests
+{
+	[Fact]
+	public void ApplyAuditTrailConfiguration_ShouldApplyConfiguration()
+	{
+		// Arrange
+		var mockBuilder = new Mock<ModelBuilder>();
+		mockBuilder.Setup(x => x.ApplyConfiguration(It.IsAny<IEntityTypeConfiguration<AuditTrail<Guid, IdentityUser<Guid>, Guid>>>()))
+			.Verifiable();
+
+		// Act
+		mockBuilder.Object.ApplyAuditTrailConfiguration<Guid, Guid, IdentityUser<Guid>>();
+
+		// Assert
+		mockBuilder.Verify(x => x.ApplyConfiguration(It.IsAny<AuditTrailConfiguration<Guid, Guid, IdentityUser<Guid>>>()), Times.Once);
+	}
+
+	[Fact]
+	public void ApplyAuditTrailConfiguration_WithIntKeys_ShouldApplyConfiguration()
+	{
+		// Arrange
+		var mockBuilder = new Mock<ModelBuilder>();
+		mockBuilder.Setup(x => x.ApplyConfiguration(It.IsAny<IEntityTypeConfiguration<AuditTrail<int, IdentityUser<int>, int>>>()))
+			.Verifiable();
+
+		// Act
+		mockBuilder.Object.ApplyAuditTrailConfiguration<int, int, IdentityUser<int>>();
+
+		// Assert
+		mockBuilder.Verify(x => x.ApplyConfiguration(It.IsAny<AuditTrailConfiguration<int, int, IdentityUser<int>>>()), Times.Once);
+	}
+
+	[Fact]
+	public void ApplyAuditTrailConfiguration_WithDifferentKeyTypes_ShouldApplyConfiguration()
+	{
+		// Arrange
+		var mockBuilder = new Mock<ModelBuilder>();
+		mockBuilder.Setup(x => x.ApplyConfiguration(It.IsAny<IEntityTypeConfiguration<AuditTrail<Guid, IdentityUser<string>, string>>>()))
+			.Verifiable();
+
+		// Act
+		mockBuilder.Object.ApplyAuditTrailConfiguration<Guid, string, IdentityUser<string>>();
+
+		// Assert
+		mockBuilder.Verify(x => x.ApplyConfiguration(It.IsAny<AuditTrailConfiguration<Guid, string, IdentityUser<string>>>()), Times.Once);
+	}
+}


### PR DESCRIPTION
Introduced `AuditTrailContextExtensions` to streamline applying audit trail configurations in the `ModelBuilder`. Added corresponding unit tests to validate correct behavior across various key type combinations.

This pull request introduces a new extension method for configuring audit trails in Entity Framework Core and includes unit tests to validate its functionality. The most important changes are the addition of the `ApplyAuditTrailConfiguration` method and corresponding test cases.

### New Extension Method for Audit Trail Configuration:
* Added the `ApplyAuditTrailConfiguration` method in `AuditTrailContextExtensions`, allowing developers to apply audit trail configurations to the `ModelBuilder` with generic key and user types. (`Domain/src/Extensions/AuditTrailContextExtensions.cs`, [Domain/src/Extensions/AuditTrailContextExtensions.csR1-R16](diffhunk://#diff-c8eb2bd80a73eccaff5a1d46a6ef331456ab3f786843ef6378935b82859c2f3bR1-R16))

### Unit Tests for the Extension Method:
* Introduced `AuditTrailContextExtensionsTests` to verify the behavior of the `ApplyAuditTrailConfiguration` method, including:
  - A test for applying configuration with `Guid` keys and `IdentityUser<Guid>`.
  - A test for applying configuration with `int` keys and `IdentityUser<int>`.
  - A test for applying configuration with mixed key types, such as `Guid` and `string`.