### PR TITLE
[Domain] Audit Store for improved naming consistency across the domain

### DIFF
--- a/Domain/src/Stores/AuditStore.cs
+++ b/Domain/src/Stores/AuditStore.cs
@@ -10,7 +10,7 @@ namespace Wangkanai.Domain.Stores;
 /// <typeparam name="TUserType">The type of the user associated with the audit trail, which must derive from <see cref="IdentityUser{T}"/>.</typeparam>
 /// <typeparam name="TUserKey">The type of the key for the user, which must implement <see cref="IEquatable{T}"/> and <see cref="IComparable{T}"/>.</typeparam>
 /// <param name="context">The database context instance to be used for accessing the audit trails.</param>
-public class AuditTrailStore<TContext, TKey, TUserType, TUserKey>(TContext context) : IQueryableAuditTrailStore<TKey, TUserType, TUserKey>
+public class AuditStore<TContext, TKey, TUserType, TUserKey>(TContext context) : IQueryableAuditStore<TKey, TUserType, TUserKey>
 	where TContext : DbContext
 	where TKey : IEquatable<TKey>, IComparable<TKey>
 	where TUserType : IdentityUser<TUserKey>

--- a/Domain/src/Stores/IAuditStore.cs
+++ b/Domain/src/Stores/IAuditStore.cs
@@ -13,11 +13,47 @@ public interface IAuditStore<TKey, TUserType, TUserKey> : IDisposable
 	where TUserType : IdentityUser<TUserKey>
 	where TUserKey : IEquatable<TUserKey>, IComparable<TUserKey>
 {
+	/// <summary>Creates a new audit entry asynchronously.</summary>
+	/// <param name="audit">The audit entity to be created.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task that represents the asynchronous operation, containing the result of the created audit.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> CreateAsync(Audit<TKey, TUserType, TUserKey> audit, CancellationToken cancellationToken);
+
+	/// <summary>Updates an existing audit entry asynchronously.</summary>
+	/// <param name="auditTrail">The audit entity to be updated.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task that represents the asynchronous operation, containing the result of the updated audit.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> UpdateAsync(Audit<TKey, TUserType, TUserKey> auditTrail, CancellationToken cancellationToken);
+
+	/// <summary>Deletes an existing audit entry asynchronously.</summary>
+	/// <param name="auditTrail">The audit entity to be deleted.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task that represents the asynchronous operation, containing the result of the deletion operation.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> DeleteAsync(Audit<TKey, TUserType, TUserKey> auditTrail, CancellationToken cancellationToken);
+
+	/// <summary>Finds an audit entry by its identifier asynchronously.</summary>
+	/// <param name="id">The unique identifier of the audit entry to be retrieved.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task that represents the asynchronous operation, containing the result of the audit entry if it exists.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByIdAsync(TKey id, CancellationToken cancellationToken);
+
+	/// <summary>Finds an audit entry by its identifier and associated user identifier asynchronously.</summary>
+	/// <param name="id">The unique identifier of the audit entry to be retrieved.</param>
+	/// <param name="userId">The unique identifier of the user associated with the audit entry.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task that represents the asynchronous operation, containing the result of the requested audit entry.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByIdAsync(TKey id, TUserKey userId, CancellationToken cancellationToken);
+
+	/// <summary>Finds an audit entry by the specified user ID asynchronously.</summary>
+	/// <param name="userId">The unique identifier of the user to search for.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task that represents the asynchronous operation, containing the result of the audit entry associated with the specified user ID.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByUserIdAsync(TUserKey userId, CancellationToken cancellationToken);
+
+	/// <summary>Finds an audit entry based on the user ID and audit ID asynchronously.</summary>
+	/// <param name="userId">The ID of the user associated with the audit entry.</param>
+	/// <param name="id">The unique identifier of the audit entry.</param>
+	/// <param name="cancellationToken">A CancellationToken to observe while waiting for the task to complete.</param>
+	/// <returns>A task representing the asynchronous operation, containing the result of the found audit entry.</returns>
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByUserIdAsync(TUserKey userId, TKey id, CancellationToken cancellationToken);
 }

--- a/Domain/src/Stores/IAuditStore.cs
+++ b/Domain/src/Stores/IAuditStore.cs
@@ -8,16 +8,16 @@ namespace Wangkanai.Domain.Stores;
 /// <typeparam name="TKey">The type of the primary key for the audit trail entity.</typeparam>
 /// <typeparam name="TUserType">The type representing the user related to the audit trail entity.</typeparam>
 /// <typeparam name="TUserKey">The type of the primary key for the user entity.</typeparam>
-public interface IAuditTrailStore<TKey, TUserType, TUserKey> : IDisposable
+public interface IAuditStore<TKey, TUserType, TUserKey> : IDisposable
 	where TKey : IEquatable<TKey>, IComparable<TKey>
 	where TUserType : IdentityUser<TUserKey>
 	where TUserKey : IEquatable<TUserKey>, IComparable<TUserKey>
 {
 	Task<Result<Audit<TKey, TUserType, TUserKey>>> CreateAsync(Audit<TKey, TUserType, TUserKey> audit, CancellationToken cancellationToken);
-	// Task<Result<AuditTrail<TKey, TUserType, TUserKey>>> UpdateAsync(AuditTrail<TKey, TUserType, TUserKey> auditTrail, CancellationToken cancellationToken);
-	// Task<Result<AuditTrail<TKey, TUserType, TUserKey>>> DeleteAsync(AuditTrail<TKey, TUserType, TUserKey> auditTrail, CancellationToken cancellationToken);
-	// Task<Result<AuditTrail<TKey, TUserType, TUserKey>>> FindByIdAsync(TKey id, CancellationToken cancellationToken);
-	// Task<Result<AuditTrail<TKey, TUserType, TUserKey>>> FindByIdAsync(TKey id, TUserKey userId, CancellationToken cancellationToken);
-	// Task<Result<AuditTrail<TKey, TUserType, TUserKey>>> FindByUserIdAsync(TUserKey userId, CancellationToken cancellationToken);
-	// Task<Result<AuditTrail<TKey, TUserType, TUserKey>>> FindByUserIdAsync(TUserKey userId, TKey id, CancellationToken cancellationToken);
+	Task<Result<Audit<TKey, TUserType, TUserKey>>> UpdateAsync(Audit<TKey, TUserType, TUserKey> auditTrail, CancellationToken cancellationToken);
+	Task<Result<Audit<TKey, TUserType, TUserKey>>> DeleteAsync(Audit<TKey, TUserType, TUserKey> auditTrail, CancellationToken cancellationToken);
+	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByIdAsync(TKey id, CancellationToken cancellationToken);
+	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByIdAsync(TKey id, TUserKey userId, CancellationToken cancellationToken);
+	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByUserIdAsync(TUserKey userId, CancellationToken cancellationToken);
+	Task<Result<Audit<TKey, TUserType, TUserKey>>> FindByUserIdAsync(TUserKey userId, TKey id, CancellationToken cancellationToken);
 }

--- a/Domain/src/Stores/IQueryableAuditStore.cs
+++ b/Domain/src/Stores/IQueryableAuditStore.cs
@@ -8,7 +8,7 @@ namespace Wangkanai.Domain.Stores;
 /// <typeparam name="TKey">The type of the unique identifier for the audit trail. It must implement <see cref="IEquatable{T}"/> and <see cref="IComparable{T}"/>. </typeparam>
 /// <typeparam name="TUserType">The type of the user associated with the audit trail. It must inherit from <see cref="IdentityUser{TUserKey}"/>.</typeparam>
 /// <typeparam name="TUserKey">The type of the unique identifier for the user. It must implement <see cref="IEquatable{T}"/> and <see cref="IComparable{T}"/>. </typeparam>
-public interface IQueryableAuditTrailStore<TKey, TUserType, TUserKey> : IAuditTrailStore<TKey, TUserType, TUserKey>
+public interface IQueryableAuditStore<TKey, TUserType, TUserKey> : IAuditStore<TKey, TUserType, TUserKey>
 	where TKey : IEquatable<TKey>, IComparable<TKey>
 	where TUserType : IdentityUser<TUserKey>
 	where TUserKey : IEquatable<TUserKey>, IComparable<TUserKey>

--- a/Domain/src/Stores/IQueryableAuditStore.cs
+++ b/Domain/src/Stores/IQueryableAuditStore.cs
@@ -1,7 +1,5 @@
 // Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
 
-using Microsoft.AspNetCore.Identity;
-
 namespace Wangkanai.Domain.Stores;
 
 /// <summary>Represents an abstraction for a queryable audit trail store, providing access to audit trail records for tracking changes in the system.</summary>


### PR DESCRIPTION
This pull request involves a renaming and refactoring effort to simplify and standardize naming conventions for audit-related classes and interfaces in the `Wangkanai.Domain.Stores` namespace. The changes primarily focus on replacing "AuditTrail" with "Audit" in class and interface names while maintaining functionality. Below are the key changes:

### Renaming and Refactoring of Classes and Interfaces:

* `Domain/src/Stores/AuditTrailStore.cs` was renamed to `Domain/src/Stores/AuditStore.cs`, and the class name was updated from `AuditTrailStore` to `AuditStore`. Additionally, the implemented interface was updated from `IQueryableAuditTrailStore` to `IQueryableAuditStore`.

* `Domain/src/Stores/IAuditTrailStore.cs` was renamed to `Domain/src/Stores/IAuditStore.cs`, and the interface name was updated from `IAuditTrailStore` to `IAuditStore`. The methods now operate on `Audit` instead of `AuditTrail`.

* `Domain/src/Stores/IQueryableAuditTrailStore.cs` was renamed to `Domain/src/Stores/IQueryableAuditStore.cs`, and the interface name was updated from `IQueryableAuditTrailStore` to `IQueryableAuditStore`. It now extends the updated `IAuditStore` interface.