### PR TITLE
Increment VersionPrefix to 3.5.0 and adjust sign.ps1 logic to skip update when `$publish` is false

### DIFF
--- a/Hosting/Directory.Build.props
+++ b/Hosting/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>3.5.0</VersionPrefix>
+		<VersionPrefix>3.4.0</VersionPrefix>
 		<Title>Wangkanai Hosting</Title>
 		<PackageTags>aspnetcore;hosting;</PackageTags>
 		<Description>Elevate your application's configuration and runtime with `Hosting`, a .NET library that puts you in control. Streamline your setup process, enhance your application's performance, and manage your project like a pro. Whether it's for an enterprise system or a personal project, `Hosting` simplifies and supercharges your application management. Join our community, discover the art of efficient configuration, and let's redefine application runtime with Hosting.</Description>

--- a/Hosting/Directory.Build.props
+++ b/Hosting/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 	<Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory)..\, Directory.Build.props))\Directory.Build.props" />
 	<PropertyGroup>
-		<VersionPrefix>3.4.0</VersionPrefix>
+		<VersionPrefix>3.5.0</VersionPrefix>
 		<Title>Wangkanai Hosting</Title>
 		<PackageTags>aspnetcore;hosting;</PackageTags>
 		<Description>Elevate your application's configuration and runtime with `Hosting`, a .NET library that puts you in control. Streamline your setup process, enhance your application's performance, and manage your project like a pro. Whether it's for an enterprise system or a personal project, `Hosting` simplifies and supercharges your application management. Join our community, discover the art of efficient configuration, and let's redefine application runtime with Hosting.</Description>

--- a/Hosting/sign.ps1
+++ b/Hosting/sign.ps1
@@ -26,7 +26,7 @@ dotnet pack .\src\ -c Release -tl -o .\artifacts --include-symbols -p:SymbolPack
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $name -o .\signed
 
-if ($publish)
+if (!$publish)
 {
     write-host "Skip update: Hosting" -ForegroundColor Yellow;
     exit;


### PR DESCRIPTION
This pull request modifies the `Hosting/sign.ps1` script to fix the conditional logic for skipping updates during the packaging process.

Key change:

* Corrected the conditional statement in the `Hosting/sign.ps1` script to check for the negation of the `$publish` variable (`if (!$publish)`), ensuring that updates are skipped only when `$publish` is `false`.