### PR TITLE
[CI] Comment out unused pull request properties in `sonar-begin.ps1` …

### DIFF
--- a/sonar-begin.ps1
+++ b/sonar-begin.ps1
@@ -8,16 +8,16 @@ write-host "Version:               " $version
 
 if ("main" -ne $env:BUILD_SOURCEBRANCHNAME) {
     $pullrequest = $true
-    $source      = $env:BUILD_SOURCEBRANCH
-    $base        = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
-    $branch      = $env:SYSTEM_PULLREQUEST_SOURCEBRANCH
-    $key         = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+#    $source      = $env:BUILD_SOURCEBRANCH
+#    $base        = $env:SYSTEM_PULLREQUEST_TARGETBRANCH
+#    $branch      = $env:SYSTEM_PULLREQUEST_SOURCEBRANCH
+#    $key         = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
 
     Write-Host "PR Yes:                   " $pullrequest
     Write-Host "soruce:                   " $source
-    Write-Host "sonar.pullrequest.base:   " $base
-    Write-Host "sonar.pullrequest.branch: " $branch
-    Write-Host "sonar.pullrequest.key:    " $key
+#    Write-Host "sonar.pullrequest.base:   " $base
+#    Write-Host "sonar.pullrequest.branch: " $branch
+#    Write-Host "sonar.pullrequest.key:    " $key
 
     dotnet sonarscanner begin `
             /k:wangkanai_wangkanai `
@@ -25,10 +25,10 @@ if ("main" -ne $env:BUILD_SOURCEBRANCHNAME) {
             /v:$version `
             /s:$sourceDir/SonarQube.Analysis.xml `
             /d:sonar.host.url=https://sonarcloud.io `
-            /d:sonar.cs.vscoveragexml.reportsPaths=$sourceDir/coverage.xml `
-            /d:sonar.pullrequest.base=$base `
-            /d:sonar.pullrequest.branch=$branch `
-            /d:sonar.pullrequest.key=$key
+            /d:sonar.cs.vscoveragexml.reportsPaths=$sourceDir/coverage.xml
+#            /d:sonar.pullrequest.base=$base `
+#            /d:sonar.pullrequest.branch=$branch `
+#            /d:sonar.pullrequest.key=$key
 }
 else
 {
@@ -43,6 +43,6 @@ else
             /v:$version `
             /s:$sourceDir/SonarQube.Analysis.xml `
             /d:sonar.host.url=https://sonarcloud.io `
-            /d:sonar.cs.vscoveragexml.reportsPaths=$sourceDir/coverage.xml `
-            /d:sonar.branch.name=$base
+            /d:sonar.cs.vscoveragexml.reportsPaths=$sourceDir/coverage.xml
+#            /d:sonar.branch.name=$base
 }


### PR DESCRIPTION
This pull request modifies the `sonar-begin.ps1` script to comment out SonarQube pull request-specific parameters. These changes simplify the script by removing the conditional logic for pull request analysis and commenting out related variables and commands.

### Changes related to pull request-specific parameters:

* Commented out the variables `source`, `base`, `branch`, and `key`, which were previously used for SonarQube pull request analysis. (`[sonar-begin.ps1L11-R31](diffhunk://#diff-061e3469b0c8addbee4e9d95ff932b64d9f8fb832d03bba275fa462eaab5cd51L11-R31)`)
* Commented out the corresponding `Write-Host` commands that logged the pull request-specific parameters. (`[sonar-begin.ps1L11-R31](diffhunk://#diff-061e3469b0c8addbee4e9d95ff932b64d9f8fb832d03bba275fa462eaab5cd51L11-R31)`)
* Removed the SonarQube pull request-specific parameters (`sonar.pullrequest.base`, `sonar.pullrequest.branch`, and `sonar.pullrequest.key`) from the `dotnet sonarscanner begin` command. (`[sonar-begin.ps1L11-R31](diffhunk://#diff-061e3469b0c8addbee4e9d95ff932b64d9f8fb832d03bba275fa462eaab5cd51L11-R31)`)
* Commented out the `sonar.branch.name` parameter in the `else` block, which is used for branch analysis. (`[sonar-begin.ps1L46-R47](diffhunk://#diff-061e3469b0c8addbee4e9d95ff932b64d9f8fb832d03bba275fa462eaab5cd51L46-R47)`)