### PR TITLE
[CI] Add `skipJreProvisioning` to SonarCloud scanner step in workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -31,7 +31,7 @@ jobs:
       run: dotnet tool install --global dotnet-sonarscanner
 
     - name: SonarCloud Scanner
-      run:  dotnet sonarscanner begin /o:"wangkanai" /k:"wangkanai_github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}"
+      run:  dotnet sonarscanner begin /o:"wangkanai" /k:"wangkanai_github" /d:sonar.host.url="https://sonarcloud.io" /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /d:sonar.scanner.skipJreProvisioning=true
 #      run:  ./sonar-begin.ps1
 #      shell: pwsh
 


### PR DESCRIPTION
This pull request includes an update to the `.github/workflows/dotnet.yml` file to enhance SonarCloud Scanner configuration.

Enhancements to SonarCloud Scanner configuration:

* [`.github/workflows/dotnet.yml`](diffhunk://#diff-d5a2cea578a0446aad66faf31bf1076ae94c9916b1a3374e342272a6300e8344L34-R34): Added the `/d:sonar.scanner.skipJreProvisioning=true` parameter to the SonarCloud Scanner command to skip JRE provisioning, optimizing the scanner setup.