### PR TITLE
[Annotations] Remove commented and unused test cases

### DIFF
--- a/Annotations/tests/NegativeIntegerAttributeTests.cs
+++ b/Annotations/tests/NegativeIntegerAttributeTests.cs
@@ -28,39 +28,12 @@ public class NegativeIntegerAttributeTests
 		var method    = typeof(NegativeInteger).GetMethod(nameof(NegativeInteger.ParameterExist));
 		var argument  = method!.GetParameters()[0];
 		var attribute = argument!.GetCustomAttribute<NegativeIntegerAttribute>();
-		var expected  = "The value must be negative integer.";
 		Assert.NotNull(attribute);
-		//Assert.Equal(expected, attribute!.Message);
-	}
-
-	[Fact]
-	public void Parameter_Attribute_Message()
-	{
-		// var method    = typeof(NegativeInteger).GetMethod(nameof(NegativeInteger.ParameterMessage));
-		// var argument  = method!.GetParameters()[0];
-		// var attribute = argument!.GetCustomAttribute<NegativeIntegerAttribute>();
-		// var expected  = "message";
-		// Assert.NotNull(attribute);
-		//Assert.Equal(expected, attribute!.Message);
-	}
-
-	[Fact]
-	public void Parameter_Attribute_Error()
-	{
-		// var method    = typeof(NegativeInteger).GetMethod(nameof(NegativeInteger.ParameterError));
-		// var argument  = method!.GetParameters()[0];
-		// var attribute = argument!.GetCustomAttribute<NegativeIntegerAttribute>();
-		// var expected  = "error";
-		// Assert.NotNull(attribute);
-		//Assert.Equal(expected, attribute!.Message);
-		//Assert.True(attribute.IsError);
 	}
 }
 
 public class NegativeInteger
 {
-	public void ParameterDefault(int                                value) { }
-	public void ParameterExist([NegativeInteger]                int value) { }
-	//public void ParameterMessage([NegativeInteger("message")]    int value) { }
-	//public void ParameterError([NegativeInteger("error", true)] int value) { }
+	public void ParameterDefault(int                 value) { }
+	public void ParameterExist([NegativeInteger] int value) { }
 }

--- a/Annotations/tests/PositiveIntegerAttributeTests.cs
+++ b/Annotations/tests/PositiveIntegerAttributeTests.cs
@@ -27,39 +27,12 @@ public class PositiveIntegerAttributeTests
 		var method    = typeof(PositiveInteger).GetMethod(nameof(PositiveInteger.ParameterExist));
 		var argument  = method!.GetParameters()[0];
 		var attribute = argument!.GetCustomAttribute<PositiveIntegerAttribute>();
-		var expected  = "The value must be positive integer.";
 		Assert.NotNull(attribute);
-		//Assert.Equal(expected, attribute!);
-	}
-
-	[Fact]
-	public void Parameter_Attribute_Message()
-	{
-		//var method    = typeof(PositiveInteger).GetMethod(nameof(PositiveInteger.ParameterMessage));
-		//var argument  = method!.GetParameters()[0];
-		//var attribute = argument!.GetCustomAttribute<PositiveIntegerAttribute>();
-		// var expected  = "message";
-		// Assert.NotNull(attribute);
-		//Assert.Equal(expected, attribute!.Message);
-	}
-
-	[Fact]
-	public void Parameter_Attribute_Error()
-	{
-		// var method    = typeof(PositiveInteger).GetMethod(nameof(PositiveInteger.ParameterError));
-		// var argument  = method!.GetParameters()[0];
-		// var attribute = argument!.GetCustomAttribute<PositiveIntegerAttribute>();
-		// var expected  = "error";
-		// Assert.NotNull(attribute);
-		//Assert.Equal(expected, attribute!.Message);
-		//Assert.True(attribute.IsError);
 	}
 }
 
 public class PositiveInteger
 {
-	public void ParameterDefault(int                                value) { }
-	public void ParameterExist([PositiveInteger]                int value) { }
-	//public void ParameterMessage([PositiveInteger("message")]   int value) { }
-	//public void ParameterError([PositiveInteger("error", true)] int value) { }
+	public void ParameterDefault(int                 value) { }
+	public void ParameterExist([PositiveInteger] int value) { }
 }

--- a/Annotations/tests/ZeroIntegerAttributeTests.cs
+++ b/Annotations/tests/ZeroIntegerAttributeTests.cs
@@ -64,14 +64,6 @@ public class ZeroIntegerAttributeTests
 	}
 
 	[Fact]
-	public void Derived_Class_Inherits_Attribute()
-	{
-		var property  = typeof(DerivedZeroInteger).GetProperty(nameof(DerivedZeroInteger.PropertyWithAttribute));
-		var attribute = property!.GetCustomAttribute<ZeroIntegerAttribute>();
-		Assert.NotNull(attribute);
-	}
-
-	[Fact]
 	public void Multiple_Parameters_With_Attribute()
 	{
 		var method        = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.MultipleParametersWithAttribute));

--- a/Annotations/tests/ZeroIntegerAttributeTests.cs
+++ b/Annotations/tests/ZeroIntegerAttributeTests.cs
@@ -18,12 +18,104 @@ public class ZeroIntegerAttributeTests
 	{
 		var method    = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.ParameterDefault));
 		var argument  = method!.GetParameters()[0];
-		var attribute = argument!.GetCustomAttribute<ZeroIntegerAttribute>();
+		var attribute = argument.GetCustomAttribute<ZeroIntegerAttribute>();
 		Assert.Null(attribute);
+	}
+
+	[Fact]
+	public void Parameter_With_Attribute()
+	{
+		var method    = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.ParameterWithAttribute));
+		var argument  = method!.GetParameters()[0];
+		var attribute = argument.GetCustomAttribute<ZeroIntegerAttribute>();
+		Assert.NotNull(attribute);
+	}
+
+	[Fact]
+	public void Property_With_Attribute()
+	{
+		var property  = typeof(ZeroInteger).GetProperty(nameof(ZeroInteger.PropertyWithAttribute));
+		var attribute = property!.GetCustomAttribute<ZeroIntegerAttribute>();
+		Assert.NotNull(attribute);
+	}
+
+	[Fact]
+	public void Property_Without_Attribute()
+	{
+		var property  = typeof(ZeroInteger).GetProperty(nameof(ZeroInteger.PropertyWithoutAttribute));
+		var attribute = property!.GetCustomAttribute<ZeroIntegerAttribute>();
+		Assert.Null(attribute);
+	}
+
+	[Fact]
+	public void Field_With_Attribute()
+	{
+		var field     = typeof(ZeroInteger).GetField("_fieldWithAttribute", BindingFlags.NonPublic | BindingFlags.Instance);
+		var attribute = field!.GetCustomAttribute<ZeroIntegerAttribute>();
+		Assert.NotNull(attribute);
+	}
+
+	[Fact]
+	public void Field_Without_Attribute()
+	{
+		var field     = typeof(ZeroInteger).GetField("_fieldWithoutAttribute", BindingFlags.NonPublic | BindingFlags.Instance);
+		var attribute = field!.GetCustomAttribute<ZeroIntegerAttribute>();
+		Assert.Null(attribute);
+	}
+
+	[Fact]
+	public void Derived_Class_Inherits_Attribute()
+	{
+		var property  = typeof(DerivedZeroInteger).GetProperty(nameof(DerivedZeroInteger.PropertyWithAttribute));
+		var attribute = property!.GetCustomAttribute<ZeroIntegerAttribute>();
+		Assert.NotNull(attribute);
+	}
+
+	[Fact]
+	public void Multiple_Parameters_With_Attribute()
+	{
+		var method        = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.MultipleParametersWithAttribute));
+		var parameters    = method!.GetParameters();
+
+		var firstAttribute  = parameters[0].GetCustomAttribute<ZeroIntegerAttribute>();
+		var secondAttribute = parameters[1].GetCustomAttribute<ZeroIntegerAttribute>();
+
+		Assert.NotNull(firstAttribute);
+		Assert.NotNull(secondAttribute);
+	}
+
+	[Fact]
+	public void Attribute_Is_Inherited()
+	{
+		var attributeType = typeof(ZeroIntegerAttribute);
+		var usageAttribute = attributeType.GetCustomAttribute<AttributeUsageAttribute>();
+
+		Assert.NotNull(usageAttribute);
+		Assert.True(usageAttribute.Inherited);
 	}
 }
 
 public class ZeroInteger
 {
 	public void ParameterDefault(int value) { }
+
+	public void ParameterWithAttribute([ZeroInteger] int value) { }
+
+	public void MultipleParametersWithAttribute([ZeroInteger] int first, [ZeroInteger] int second) { }
+
+	[ZeroInteger]
+	public int PropertyWithAttribute { get; set; }
+
+	public int PropertyWithoutAttribute { get; set; }
+
+	[ZeroInteger]
+	private int _fieldWithAttribute = 0;
+
+	private int _fieldWithoutAttribute = 0;
+}
+
+public class DerivedZeroInteger : ZeroInteger
+{
+	// This property will inherit the attribute from the base class
+	public new int PropertyWithAttribute { get; set; }
 }

--- a/Annotations/tests/ZeroIntegerAttributeTests.cs
+++ b/Annotations/tests/ZeroIntegerAttributeTests.cs
@@ -21,46 +21,9 @@ public class ZeroIntegerAttributeTests
 		var attribute = argument!.GetCustomAttribute<ZeroIntegerAttribute>();
 		Assert.Null(attribute);
 	}
-
-	[Fact]
-	public void Parameter_Attribute_Exist()
-	{
-		// var method    = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.ParameterExit));
-		// var argument  = method!.GetParameters()[0];
-		// var attribute = argument!.GetCustomAttribute<ZeroIntegerAttribute>();
-		// var expected  = "The value must be zero integer.";
-		// Assert.NotNull(attribute);
-		// Assert.Equal(expected, attribute!.Message);
-	}
-
-	[Fact]
-	public void Parameter_Attribute_Message()
-	{
-		// var method    = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.ParameterMessage));
-		// var argument  = method!.GetParameters()[0];
-		// var attribute = argument!.GetCustomAttribute<ZeroIntegerAttribute>();
-		// var expected  = "message";
-		// Assert.NotNull(attribute);
-		// Assert.Equal(expected, attribute!.Message);
-	}
-
-	[Fact]
-	public void Parameter_Attribute_Error()
-	{
-		// var method    = typeof(ZeroInteger).GetMethod(nameof(ZeroInteger.ParameterError));
-		// var argument  = method!.GetParameters()[0];
-		// var attribute = argument!.GetCustomAttribute<ZeroIntegerAttribute>();
-		// var expected  = "error";
-		// Assert.NotNull(attribute);
-		// Assert.Equal(expected, attribute!.Message);
-		// Assert.True(attribute.IsError);
-	}
 }
 
 public class ZeroInteger
 {
-	public void ParameterDefault(int                            value) { }
-	public void ParameterExit([ZeroInteger]                 int value) { }
-	// public void ParameterMessage([ZeroInteger("message")] int value) { }
-	// public void ParameterError([ZeroInteger("error", true)] int value) { }
+	public void ParameterDefault(int value) { }
 }


### PR DESCRIPTION
This pull request simplifies the `NegativeIntegerAttributeTests` class by removing unused test methods and redundant code. It also cleans up the `NegativeInteger` class by eliminating commented-out methods related to unused attributes.

Changes to `NegativeIntegerAttributeTests`:

* Removed the `Parameter_Attribute_Message` and `Parameter_Attribute_Error` test methods, which were commented out and unused.
* Removed assertions and expected values related to the `Message` property in the `Parameter_Attribute_Exist` test method.

Changes to `NegativeInteger`:

* Deleted commented-out methods `ParameterMessage` and `ParameterError` that were not actively used.