### PR TITLE
[CI] dotnet-coverage global tool

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -53,7 +53,7 @@ jobs:
       run:  dotnet build --no-restore
 
     - name: Test
-      run:  dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
+      run:  dotnet-coverage collect "dotnet test --no-build --verbosity normal" -f xml -o "coverage.xml"
 #      run:  dotnet test  --no-build --verbosity normal --collect "Code Coverage"
 
     - name: SonarCloud Submit

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash
 
     - name: SonarCloud Scanner
-      run:  dotnet sonarscanner begin /o:"wangkanai" /k:"wangkanai_github" /d:sonar.host.url="https://sonarcloud.io" /v:${{ env.VERSION }} /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /s:${{ github.workspace }}/SonarQube.Analysis.xml /d:sonar.scanner.skipJreProvisioning=true /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+      run:  dotnet sonarscanner begin /o:"wangkanai" /k:"wangkanai_github" /d:sonar.host.url="https://sonarcloud.io" /v:${{ env.VERSION }} /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /s:${{ github.workspace }}/SonarQube.Analysis.xml /d:sonar.scanner.skipJreProvisioning=true /d:sonar.cs.vscoveragexml.reportsPaths=${{ github.workspace }}/coverage.xml
 
     - name: Restore dependencies
       run:  dotnet restore
@@ -54,7 +54,6 @@ jobs:
 
     - name: Test
       run:  dotnet-coverage collect "dotnet test --no-build --verbosity normal" -f xml -o "coverage.xml"
-#      run:  dotnet test  --no-build --verbosity normal --collect "Code Coverage"
 
     - name: SonarCloud Submit
       run:  dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -32,16 +32,19 @@ jobs:
       with:
         dotnet-version: 9.0.x
 
-    - name: SonarCloud Tools
-      run: dotnet tool install --global dotnet-sonarscanner
+    - name: Setup SonarCloud
+      run:  dotnet tool install --global dotnet-sonarscanner
 
-    - name: SonarCloud Scanner
-      run:  dotnet sonarscanner begin /o:"wangkanai" /k:"wangkanai_github" /d:sonar.host.url="https://sonarcloud.io" /v:${{ env.VERSION }} /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /s:${{ github.workspace }}/SonarQube.Analysis.xml /d:sonar.scanner.skipJreProvisioning=true /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
+    - name: Setup Coverage
+      run:  dotnet tool install --global dotnet-coverage
 
     - name: Install npm
       run: |
         npm install -g rimraf
       shell: bash
+
+    - name: SonarCloud Scanner
+      run:  dotnet sonarscanner begin /o:"wangkanai" /k:"wangkanai_github" /d:sonar.host.url="https://sonarcloud.io" /v:${{ env.VERSION }} /d:sonar.token="${{ secrets.SONAR_TOKEN }}" /s:${{ github.workspace }}/SonarQube.Analysis.xml /d:sonar.scanner.skipJreProvisioning=true /d:sonar.cs.vscoveragexml.reportsPaths=coverage.xml
 
     - name: Restore dependencies
       run:  dotnet restore
@@ -50,7 +53,8 @@ jobs:
       run:  dotnet build --no-restore
 
     - name: Test
-      run:  dotnet test  --no-build --verbosity normal --collect "Code Coverage"
+      run:  dotnet-coverage collect "dotnet test" -f xml -o "coverage.xml"
+#      run:  dotnet test  --no-build --verbosity normal --collect "Code Coverage"
 
     - name: SonarCloud Submit
       run:  dotnet sonarscanner end /d:sonar.token="${{ secrets.SONAR_TOKEN }}"


### PR DESCRIPTION
This pull request updates the `.github/workflows/dotnet.yml` file to improve the CI/CD pipeline by reorganizing SonarCloud and code coverage setup steps and switching to the `dotnet-coverage` tool for collecting test coverage data.

### CI/CD Pipeline Improvements:

* Reorganized SonarCloud setup: Renamed the step to "Setup SonarCloud" and moved the SonarCloud scanner step to follow npm installation for better logical grouping.
* Added a new step for setting up `dotnet-coverage`: Installed the `dotnet-coverage` tool globally for collecting test coverage data.
* Updated test coverage collection: Replaced the `dotnet test` command with `dotnet-coverage collect` to generate coverage data in XML format.