### PR TITLE
[CI] Comment out `sonar.branch.name` property in SonarQube.Analysis.xml

### DIFF
--- a/SonarQube.Analysis.xml
+++ b/SonarQube.Analysis.xml
@@ -2,7 +2,7 @@
     <!-- Mandatory-->
     <Property Name="sonar.host.url">https://sonarcloud.io</Property>
     <!-- Generic  -->
-    <Property Name="sonar.branch.name">main</Property>
+	<!--<Property Name="sonar.branch.name">main</Property>-->
     <Property Name="sonar.sourceEncoding">UTF-8</Property>
     <!-- <Property Name="sonar.project.monorepo.enabled">true</Property> -->
     <!-- Source   -->


### PR DESCRIPTION
This pull request includes a small change to the `SonarQube.Analysis.xml` file. The change comments out the `sonar.branch.name` property, which was previously set to `main`.