### PR TITLE
[System] Fix `BinarySearch` null check to use `EqualityComparer<T>.De…

### DIFF
--- a/System/src/Collections/RandomAccessQueue.cs
+++ b/System/src/Collections/RandomAccessQueue.cs
@@ -374,7 +374,7 @@ public sealed class RandomAccessQueue<T> : ICollection<T>, ICollection, ICloneab
 	public int BinarySearch(T value)
 	{
 		if (value is null)
-			if (_count == 0 || _buffer[_start] != null)
+			if (_count == 0 || !EqualityComparer<T>.Default.Equals(_buffer[_start], default))
 				return ~0;
 			else
 				return 0;


### PR DESCRIPTION
This pull request includes a minor yet impactful change to the `BinarySearch` method in the `RandomAccessQueue` class. The update improves null-checking logic by replacing direct null comparison with `EqualityComparer<T>.Default.Equals`, ensuring better compatibility with generic types.