### PR TITLE
[System] Introduce `EqualNull` and 'NotNull'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -100,9 +100,10 @@ dotnet_sort_system_directives_first                =true
 dotnet_separate_import_directive_groups            =true
 resharper_sort_system_directives_first             =true
 ij_any_align_multiline_array_initializer_expression=true
+resharper_csharp_space_before_trailing_comment     =false
 
 [*.{cs, cpp, h}]
-file_header_template=Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+file_header_template=Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
 
 [*.{html, cshtml}]
 indent_size                           =4

--- a/System/src/Checks/NullEqualityComparerExtensions.cs
+++ b/System/src/Checks/NullEqualityComparerExtensions.cs
@@ -11,4 +11,11 @@ public static class NullEqualityComparerExtensions
 	/// <returns>True if the specified value is null or the default for the type; otherwise, false.</returns>
 	public static bool EqualNull<T>(this T? value)
 		=> EqualityComparer<T>.Default.Equals(value, default);
+
+	/// <summary>Determines whether the specified value is not equal to null or the default value of the type.</summary>
+	/// <typeparam name="T">The type of the value to compare.</typeparam>
+	/// <param name="value">The value to be compared.</param>
+	/// <returns>True if the specified value is not null and not the default for the type; otherwise, false.</returns>
+	public static bool NotNull<T>(this T? value)
+		=> !value.EqualNull();
 }

--- a/System/src/Checks/NullEqualityComparerExtensions.cs
+++ b/System/src/Checks/NullEqualityComparerExtensions.cs
@@ -1,0 +1,14 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai;
+
+[DebuggerStepThrough]
+public static class NullEqualityComparerExtensions
+{
+	/// <summary>Determines whether the specified value is equal to null or the default value of the type.</summary>
+	/// <typeparam name="T">The type of the value to compare.</typeparam>
+	/// <param name="value">The value to be compared.</param>
+	/// <returns>True if the specified value is null or the default for the type; otherwise, false.</returns>
+	public static bool EqualNull<T>(this T? value)
+		=> EqualityComparer<T>.Default.Equals(value, default);
+}

--- a/System/src/Checks/NullEqualityExtensions.cs
+++ b/System/src/Checks/NullEqualityExtensions.cs
@@ -3,7 +3,7 @@
 namespace Wangkanai;
 
 [DebuggerStepThrough]
-public static class NullEqualityComparerExtensions
+public static class NullEqualityExtensions
 {
 	/// <summary>Determines whether the specified value is equal to null or the default value of the type.</summary>
 	/// <typeparam name="T">The type of the value to compare.</typeparam>

--- a/System/src/Collections/RandomAccessQueue.cs
+++ b/System/src/Collections/RandomAccessQueue.cs
@@ -374,7 +374,7 @@ public sealed class RandomAccessQueue<T> : ICollection<T>, ICollection, ICloneab
 	public int BinarySearch(T value)
 	{
 		if (value is null)
-			if (_count == 0 || !EqualityComparer<T>.Default.Equals(_buffer[_start], default))
+			if (_count == 0 || !_buffer[_start].EqualNull())
 				return ~0;
 			else
 				return 0;

--- a/System/src/Collections/RandomAccessQueue.cs
+++ b/System/src/Collections/RandomAccessQueue.cs
@@ -374,7 +374,7 @@ public sealed class RandomAccessQueue<T> : ICollection<T>, ICollection, ICloneab
 	public int BinarySearch(T value)
 	{
 		if (value is null)
-			if (_count == 0 || !_buffer[_start].EqualNull())
+			if (_count == 0 || _buffer[_start].NotNull())
 				return ~0;
 			else
 				return 0;

--- a/System/src/Decorator.cs
+++ b/System/src/Decorator.cs
@@ -1,10 +1,8 @@
-﻿// Copyright (c) 2014-2024 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+﻿// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
 
 namespace Wangkanai;
 
-/// <summary>
-/// Represents a generic decorator that wraps an instance of a specified type.
-/// </summary>
+/// <summary>Represents a generic decorator that wraps an instance of a specified type.</summary>
 /// <param name="instance">The instance to be wrapped and implemented.</param>
 /// <typeparam name="TService">The type of the instance to be wrapped.</typeparam>
 public class Decorator<TService>(TService instance)
@@ -12,25 +10,19 @@ public class Decorator<TService>(TService instance)
 	public TService Instance { get; } = instance;
 }
 
-/// <summary>
-/// Represents a generic decorator that wraps an instance of a specified type.
-/// </summary>
+/// <summary>Represents a generic decorator that wraps an instance of a specified type.</summary>
 /// <param name="instance">The instance to be wrapped and implemented.</param>
 /// <typeparam name="TService">The type of the instance to be wrapped.</typeparam>
 /// <typeparam name="TImplementation">The type of the instance to be implemented.</typeparam>
 public class Decorator<TService, TImplementation>(TImplementation instance) : Decorator<TService>(instance)
 	where TImplementation : class, TService;
 
-/// <summary>
-/// Represents a generic decorator that wraps an instance of a specified type and implements <see cref="IDisposable"/>.
-/// </summary>
+/// <summary>Represents a generic decorator that wraps an instance of a specified type and implements <see cref="IDisposable"/>.</summary>
 /// <param name="instance">The instance to be wrapped and implemented.</param>
 /// <typeparam name="TService">The type of the instance to be wrapped.</typeparam>
 public class DisposableDecorator<TService>(TService instance) : Decorator<TService>(instance), IDisposable
 {
-	/// <summary>
-	/// Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.
-	/// </summary>
+	/// <summary>Performs application-defined tasks associated with freeing, releasing, or resetting unmanaged resources.</summary>
 	public void Dispose()
 	{
 		(Instance as IDisposable)?.Dispose();

--- a/System/src/Extensions/DictionaryExtensions.cs
+++ b/System/src/Extensions/DictionaryExtensions.cs
@@ -8,9 +8,7 @@ namespace Wangkanai.Extensions;
 [DebuggerStepThrough]
 public static class DictionaryExtensions
 {
-	/// <summary>
-	/// Returns the value associated with the specified key from the dictionary or throws a KeyNotFoundException with the specified exception message if the key does not exist.
-	/// </summary>
+	/// <summary>Returns the value associated with the specified key from the dictionary or throws a KeyNotFoundException with the specified exception message if the key does not exist.</summary>
 	/// <typeparam name="TKey">The type of the key in the dictionary.</typeparam>
 	/// <typeparam name="TValue">The type of the value in the dictionary.</typeparam>
 	/// <param name="dictionary">The dictionary to retrieve the value from.</param>
@@ -23,21 +21,16 @@ public static class DictionaryExtensions
 			   ? throw new KeyNotFoundException(exceptionMessage)
 			   : value;
 
-	/// <summary>
-	/// Doesn't throw an exception when the key is null or does not exist. Returns the value associated with the specified key from the dictionary, or a default value if the key is null or does not exist.
-	/// </summary>
+	/// <summary>Doesn't throw an exception when the key is null or does not exist. Returns the value associated with the specified key from the dictionary, or a default value if the key is null or does not exist. </summary>
 	/// <typeparam name="TKey">The type of the key in the dictionary.</typeparam>
 	/// <typeparam name="TValue">The type of the value in the dictionary.</typeparam>
 	/// <param name="dictionary">The dictionary to retrieve the value from.</param>
 	/// <param name="key">The key to retrieve the value for.</param>
-	/// <param name="defaultValue">The default value to be returned if the key is null or does not exist.</param>
 	/// <returns>The value associated with the key, or the default value if the key is null or does not exist.</returns>
 	public static TValue GetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
 		=> dictionary!.GetValueSafe(key, default)!;
 
-	/// <summary>
-	/// Doesn't throw an exception when the key is null or does not exist. Returns the value associated with the specified key from the dictionary, or a default value if the key is null or does not exist.
-	/// </summary>
+	/// <summary>Doesn't throw an exception when the key is null or does not exist. Returns the value associated with the specified key from the dictionary, or a default value if the key is null or does not exist.</summary>
 	/// <typeparam name="TKey">The type of the key in the dictionary.</typeparam>
 	/// <typeparam name="TValue">The type of the value in the dictionary.</typeparam>
 	/// <param name="dictionary">The dictionary to retrieve the value from.</param>
@@ -49,9 +42,7 @@ public static class DictionaryExtensions
 			   ? defaultValue
 			   : value;
 
-	/// <summary>
-	/// Returns the value associated with the specified key from the dictionary, allowing for safe retrieval without throwing a KeyNotFoundException if the key does not exist.
-	/// </summary>
+	/// <summary>Returns the value associated with the specified key from the dictionary, allowing for safe retrieval without throwing a KeyNotFoundException if the key does not exist.</summary>
 	/// <typeparam name="TKey">The type of the key in the dictionary.</typeparam>
 	/// <typeparam name="TValue">The type of the value in the dictionary.</typeparam>
 	/// <param name="dictionary">The dictionary to retrieve the value from.</param>

--- a/System/src/Extensions/DictionaryExtensions.cs
+++ b/System/src/Extensions/DictionaryExtensions.cs
@@ -45,7 +45,7 @@ public static class DictionaryExtensions
 	/// <param name="defaultValue">The default value to be returned if the key is null or does not exist.</param>
 	/// <returns>The value associated with the key, or the default value if the key is null or does not exist.</returns>
 	public static TValue GetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
-		=> EqualityComparer<TKey>.Default.Equals(key, default) || !dictionary.TryGetValue(key, out var value)
+		=> key.EqualNull() || !dictionary.TryGetValue(key, out var value)
 			   ? defaultValue
 			   : value;
 
@@ -60,7 +60,7 @@ public static class DictionaryExtensions
 	/// <returns>true if the dictionary contains an element with the specified key; otherwise, false.</returns>
 	public static bool TryGetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, out TValue value)
 	{
-		if (!EqualityComparer<TKey>.Default.Equals(key, default))
+		if (key.NotNull())
 			return dictionary.TryGetValue(key, out value!);
 		value = default!;
 		return false;

--- a/System/src/Math.cs
+++ b/System/src/Math.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
 
 namespace Wangkanai;
 
@@ -7,90 +7,70 @@ namespace Wangkanai;
 /// </summary>
 public static partial class Math
 {
-	/// <summary>
-	/// Divides two byte values.
-	/// </summary>
+	/// <summary>Divides two byte values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static byte Divider(byte value, byte divider)
 		=> (byte)(divider != 0 ? value / divider : 0);
 
-	/// <summary>
-	/// Divides two sbyte values.
-	/// </summary>
+	/// <summary>Divides two sbyte values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static sbyte Divider(sbyte value, sbyte divider)
 		=> (sbyte)(divider != 0 ? value / divider : 0);
 
-	/// <summary>
-	/// Divides two short values.
-	/// </summary>
+	/// <summary>Divides two short values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static short Divider(short value, short divider)
 		=> (short)(divider != 0 ? value / divider : 0);
 
-	/// <summary>
-	/// Divides two int values.
-	/// </summary>
+	/// <summary>Divides two int values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static int Divider(int value, int divider)
 		=> divider != 0 ? value / divider : 0;
 
-	/// <summary>
-	/// Divides two uint values.
-	/// </summary>
+	/// <summary>Divides two uint values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static uint Divider(uint value, uint divider)
 		=> divider != 0 ? value / divider : 0;
 
-	/// <summary>
-	/// Divides two long values.
-	/// </summary>
+	/// <summary>Divides two long values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static long Divider(long value, long divider)
 		=> divider != 0 ? value / divider : 0;
 
-	/// <summary>
-	/// Divides two ulong values.
-	/// </summary>
+	/// <summary>Divides two ulong values. </summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static ulong Divider(ulong value, ulong divider)
 		=> divider != 0 ? value / divider : 0;
 
-	/// <summary>
-	/// Divides two float values.
-	/// </summary>
+	/// <summary>Divides two float values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static float Divider(float value, float divider)
 		=> System.Math.Abs(divider) >= float.Epsilon ? value / divider : 0;
 
-	/// <summary>
-	/// Divides two double values.
-	/// </summary>
+	/// <summary>Divides two double values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>
 	public static double Divider(double value, double divider)
 		=> System.Math.Abs(divider) >= double.Epsilon ? value / divider : 0;
 
-	/// <summary>
-	/// Divides two decimal values.
-	/// </summary>
+	/// <summary>Divides two decimal values.</summary>
 	/// <param name="value">The dividend.</param>
 	/// <param name="divider">The divisor.</param>
 	/// <returns>The quotient of the division. If the divisor is 0, returns 0.</returns>

--- a/System/src/StaticRandom.cs
+++ b/System/src/StaticRandom.cs
@@ -1,72 +1,56 @@
-﻿// Copyright (c) 2014-2022 Sarin Na Wangkanai, All Rights Reserved.Apache License, Version 2.0
+﻿// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
 
 namespace Wangkanai;
 
-/// <summary>
-/// Represents a static class that provides random number generation functionality.
-/// </summary>
+/// <summary>Represents a static class that provides random number generation functionality.</summary>
 public static class StaticRandom
 {
 	private static readonly Random Random = new Random();
 	private static readonly object Lock   = new object();
 
-	/// <summary>
-	/// Generates a random integer.
-	/// </summary>
+	/// <summary>Generates a random integer.</summary>
 	/// <returns>A random integer.</returns>
 	public static int Next()
 	{
 		lock (Lock) return Random.Next();
 	}
 
-	/// <summary>
-	/// Generates a random integer.
-	/// </summary>
+	/// <summary>Generates a random integer.</summary>
 	/// <returns>A random integer.</returns>
 	public static int Next(int max)
 	{
 		lock (Lock) return Random.Next(max);
 	}
 
-	/// <summary>
-	/// Generates a random integer.
-	/// </summary>
+	/// <summary>Generates a random integer.</summary>
 	/// <returns>A random integer.</returns>
 	public static int Next(int min, int max)
 	{
 		lock (Lock) return Random.Next(min, max);
 	}
 
-	/// <summary>
-	/// Generates a random double between 0.0 and 1.0.
-	/// </summary>
+	/// <summary>Generates a random double between 0.0 and 1.0.</summary>
 	/// <returns>A random double between 0.0 and 1.0.</returns>
 	public static double NextDouble()
 	{
 		lock (Lock) return Random.NextDouble();
 	}
 
-	/// <summary>
-	/// Generates random bytes and fills the provided byte array with the generated values.
-	/// </summary>
+	/// <summary>Generates random bytes and fills the provided byte array with the generated values.</summary>
 	/// <param name="buffer">The byte array to fill with random values.</param>
 	public static void NextBytes(byte[] buffer)
 	{
 		lock (Lock) Random.NextBytes(buffer);
 	}
 
-	/// <summary>
-	/// Generates random bytes and fills the provided byte array with the generated values.
-	/// </summary>
+	/// <summary> Generates random bytes and fills the provided byte array with the generated values.</summary>
 	/// <param name="buffer">The byte array to fill with random values.</param>
 	public static void NextBytes(Span<byte> buffer)
 	{
 		lock (Lock) Random.NextBytes(buffer);
 	}
 
-	/// <summary>
-	/// Generates random bytes and fills the provided byte array with the generated values.
-	/// </summary>
+	/// <summary> Generates random bytes and fills the provided byte array with the generated values.</summary>
 	/// <param name="buffer">The byte array to fill with random values.</param>
 	public static void NextBytes(Memory<byte> buffer)
 	{

--- a/System/tests/Checks/NullEqualityTests.cs
+++ b/System/tests/Checks/NullEqualityTests.cs
@@ -1,0 +1,8 @@
+// Copyright (c) 2014-2025 Sarin Na Wangkanai, All Rights Reserved. Apache License, Version 2.0
+
+namespace Wangkanai.Checks;
+
+public class NullEqualityTests
+{
+
+}

--- a/System/tests/Checks/NullEqualityTests.cs
+++ b/System/tests/Checks/NullEqualityTests.cs
@@ -4,5 +4,302 @@ namespace Wangkanai.Checks;
 
 public class NullEqualityTests
 {
+    #region EqualNull Tests
 
+    [Fact]
+    public void EqualNull_WithNullReferenceType_ReturnsTrue()
+    {
+        string value = null;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonNullReferenceType_ReturnsFalse()
+    {
+        string value = "test";
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithEmptyString_ReturnsFalse()
+    {
+        string value = string.Empty;
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithDefaultInt_ReturnsTrue()
+    {
+        int value = default;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonDefaultInt_ReturnsFalse()
+    {
+        int value = 42;
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNullableIntNull_ReturnsTrue()
+    {
+        int? value = null;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNullableIntZero_ReturnsFalse()
+    {
+        int? value = 0;
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNullableIntNonZero_ReturnsFalse()
+    {
+        int? value = 42;
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithDefaultGuid_ReturnsTrue()
+    {
+        Guid value = default;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonDefaultGuid_ReturnsFalse()
+    {
+        Guid value = Guid.NewGuid();
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithDefaultDateTime_ReturnsTrue()
+    {
+        DateTime value = default;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonDefaultDateTime_ReturnsFalse()
+    {
+        DateTime value = DateTime.Now;
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithDefaultEnum_ReturnsTrue()
+    {
+        DayOfWeek value = default;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonDefaultEnum_ReturnsFalse()
+    {
+        DayOfWeek value = DayOfWeek.Friday;
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithDefaultBool_ReturnsTrue()
+    {
+        bool value = default;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithTrueBool_ReturnsFalse()
+    {
+        bool value = true;
+        Assert.False(value.EqualNull());
+    }
+
+    #endregion
+
+    #region NotNull Tests
+
+    [Fact]
+    public void NotNull_WithNullReferenceType_ReturnsFalse()
+    {
+        string value = null;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonNullReferenceType_ReturnsTrue()
+    {
+        string value = "test";
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithEmptyString_ReturnsTrue()
+    {
+        string value = string.Empty;
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithDefaultInt_ReturnsFalse()
+    {
+        int value = default;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonDefaultInt_ReturnsTrue()
+    {
+        int value = 42;
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNullableIntNull_ReturnsFalse()
+    {
+        int? value = null;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNullableIntZero_ReturnsTrue()
+    {
+        int? value = 0;
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNullableIntNonZero_ReturnsTrue()
+    {
+        int? value = 42;
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithDefaultGuid_ReturnsFalse()
+    {
+        Guid value = default;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonDefaultGuid_ReturnsTrue()
+    {
+        Guid value = Guid.NewGuid();
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithDefaultDateTime_ReturnsFalse()
+    {
+        DateTime value = default;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonDefaultDateTime_ReturnsTrue()
+    {
+        DateTime value = DateTime.Now;
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithDefaultEnum_ReturnsFalse()
+    {
+        DayOfWeek value = default;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonDefaultEnum_ReturnsTrue()
+    {
+        DayOfWeek value = DayOfWeek.Friday;
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithDefaultBool_ReturnsFalse()
+    {
+        bool value = default;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithTrueBool_ReturnsTrue()
+    {
+        bool value = true;
+        Assert.True(value.NotNull());
+    }
+
+    #endregion
+
+    #region Custom Types
+
+    [Fact]
+    public void EqualNull_WithNullCustomClass_ReturnsTrue()
+    {
+        TestClass value = null;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonNullCustomClass_ReturnsFalse()
+    {
+        TestClass value = new TestClass();
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNullCustomClass_ReturnsFalse()
+    {
+        TestClass value = null;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonNullCustomClass_ReturnsTrue()
+    {
+        TestClass value = new TestClass();
+        Assert.True(value.NotNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithDefaultStruct_ReturnsTrue()
+    {
+        TestStruct value = default;
+        Assert.True(value.EqualNull());
+    }
+
+    [Fact]
+    public void EqualNull_WithNonDefaultStruct_ReturnsFalse()
+    {
+        TestStruct value = new TestStruct { Value = 42 };
+        Assert.False(value.EqualNull());
+    }
+
+    [Fact]
+    public void NotNull_WithDefaultStruct_ReturnsFalse()
+    {
+        TestStruct value = default;
+        Assert.False(value.NotNull());
+    }
+
+    [Fact]
+    public void NotNull_WithNonDefaultStruct_ReturnsTrue()
+    {
+        TestStruct value = new TestStruct { Value = 42 };
+        Assert.True(value.NotNull());
+    }
+
+    #endregion
+
+    private class TestClass { }
+
+    private struct TestStruct
+    {
+        public int Value { get; set; }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new utility class `NullEqualityComparerExtensions` to simplify null and default value checks, and updates existing code in `RandomAccessQueue` to leverage this new functionality for improved readability and maintainability.

### New utility class for null checks:

* [`System/src/Checks/NullEqualityComparerExtensions.cs`](diffhunk://#diff-4dc1cdff26dcd760ed42ad0f5cce4db1087055fa6b05443ef54c851dc8479af5R1-R21): Added a static class `NullEqualityComparerExtensions` with two extension methods, `EqualNull` and `NotNull`, to determine whether a value is null or the default value of its type.

### Code updates using the new utility:

* [`System/src/Collections/RandomAccessQueue.cs`](diffhunk://#diff-0819155482bc46e0c2e294b475ab624828a5e5a11849ed15c65ef7fec3e24504L377-R377): Updated the `BinarySearch` method in `public IEnumerator<T> GetEnumerator()` to use the new `NotNull` extension method, simplifying the null-check logic.