### PR TITLE
[Build] Standardize asset paths in `Directory.Build.props` files to u…

### DIFF
--- a/Analytics/Directory.Build.props
+++ b/Analytics/Directory.Build.props
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Analytics'">
-		<None Include="..\..\assets\analytics-logo.png" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\analytics-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 

--- a/Annotations/Directory.Build.props
+++ b/Annotations/Directory.Build.props
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 </Project>

--- a/Cryptography/Directory.Build.props
+++ b/Cryptography/Directory.Build.props
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Cryptography'">
-		<None Include="..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 

--- a/EntityFramework/Directory.Build.props
+++ b/EntityFramework/Directory.Build.props
@@ -15,8 +15,8 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.EntityFramework'">
-		<None Include="..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
-		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 
 </Project>

--- a/Extensions/FileProviders/Directory.Build.props
+++ b/Extensions/FileProviders/Directory.Build.props
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Extensions.FileProviders'">
-    <None Include="..\..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+    <None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/Extensions/Html/Directory.Build.props
+++ b/Extensions/Html/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Extensions.Html'">
-    <None Include="..\..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+    <None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/Extensions/Internal/Directory.Build.props
+++ b/Extensions/Internal/Directory.Build.props
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(MSBuildProjectName)' == 'Wangkanai.Extensions.Internal'">
-    <None Include="..\..\..\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
+    <None Include="$(RepoRoot)\assets\wangkanai-logo.png" Pack="true" PackagePath="\" />
     <None Include="..\README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 </Project>

--- a/Federation/Directory.Build.props
+++ b/Federation/Directory.Build.props
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-		<None Include="..\..\..\assets\federation-logo.png" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\federation-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 

--- a/Identity/Directory.Build.props
+++ b/Identity/Directory.Build.props
@@ -15,7 +15,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectDirectory.Contains('src'))">
-		<None Include="..\..\assets\federation-logo.png" Pack="true" PackagePath="\" />
+		<None Include="$(RepoRoot)\assets\federation-logo.png" Pack="true" PackagePath="\" />
 		<None Include="..\..\README.md" Pack="true" PackagePath="\" />
 	</ItemGroup>
 


### PR DESCRIPTION
This pull request standardizes the path references to asset files across multiple projects by replacing relative paths with the `$(RepoRoot)` variable. This change improves maintainability and ensures consistency in asset file references.

### Path Standardization Changes:
* [`Analytics/Directory.Build.props`](diffhunk://#diff-a5661d71d83ed024558a4b3225ba799b0a3fcb99a20b50057ae1b18e7b179392L19-R19): Updated the path to `analytics-logo.png` to use `$(RepoRoot)` for consistency.
* [`Annotations/Directory.Build.props`](diffhunk://#diff-4c00098e388a63924daa1093ceb9028d85eefc55a6ed37c3091b2ff825633878L18-R18): Replaced the relative path to `wangkanai-logo.png` with `$(RepoRoot)`.
* [`Cryptography/Directory.Build.props`](diffhunk://#diff-3867dc460ff65a7cba4be125a666c6abc26a2e6225bc2b75cce3168bab650178L19-R19): Standardized the path to `wangkanai-logo.png` using `$(RepoRoot)`.
* [`EntityFramework/Directory.Build.props`](diffhunk://#diff-2f217692153bd042b0b7933ddb015eb4faad0feb7031aa5fc869cf22e7079ebeL18-R19): Updated paths for `wangkanai-logo.png` and `README.md` to use `$(RepoRoot)`.
* `Extensions/FileProviders/Directory.Build.props`, `Extensions/Html/Directory.Build.props`, `Extensions/Internal/Directory.Build.props`: Adjusted paths to `wangkanai-logo.png` to use `$(RepoRoot)` for uniformity. [[1]](diffhunk://#diff-9ad687c4a6be959daa44fd207e79e3f424ab97e84d93863259059460bd3452aeL18-R18) [[2]](diffhunk://#diff-5610d9a74400949a42a8d7204f79e295f98d9091f2e8ba1bbb41eeb61958c8f2L16-R16) [[3]](diffhunk://#diff-9625351b8caaf777b9eed580f8316c7abef31517ca8076b647e108a95f8390b5L16-R16)

### Federation and Identity Projects:
* [`Federation/Directory.Build.props`](diffhunk://#diff-8b75e58e9c5a9d031844d3b08bee2a16ca1a560eb5bc0b301bb494d62c859d37L20-R20): Modified the path to `federation-logo.png` to use `$(RepoRoot)` for consistency.
* [`Identity/Directory.Build.props`](diffhunk://#diff-7f9f0d4a2657774b945ad6e3eec4243ec881081c37cf958739372f45797b5422L18-R18): Standardized the path to `federation-logo.png` using `$(RepoRoot)`.