### PR TITLE
[xunit] add xunit analyzers

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(MSBuildProjectName.Contains('Tests'))">
-		<Using Include="Xunit" />
+		<Using Include="Xunit"/>
 	</ItemGroup>
 
 	<!-- GitHub Source Link -->
@@ -30,6 +30,7 @@
 		<PackageReference Include="Moq"/>
 		<PackageReference Include="xunit.v3"/>
 		<PackageReference Include="xunit.runner.visualstudio"/>
+		<PackageReference Include="xunit.analyzers"/>
 		<PackageReference Include="coverlet.collector"/>
 		<PackageReference Include="coverlet.msbuild"/>
 		<PackageReference Include="FluentAssertions"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -55,6 +55,7 @@
     <PackageVersion Include="Moq" Version="4.20.72" />
 		<PackageVersion Include="xunit.v3" Version="2.0.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" PrivateAssets="all"/>
+		<PackageVersion Include="xunit.analyzers" Version="1.22.0" PrivateAssets="all" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="all" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="all" />
     <PackageVersion Include="FluentAssertions" Version="8.3.0" />


### PR DESCRIPTION
This pull request introduces a new dependency, `xunit.analyzers`, to the project. The changes ensure that the `xunit.analyzers` package is referenced and its version is specified for consistent usage across the project.

Dependency updates:

* [`Directory.Build.targets`](diffhunk://#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcR33): Added a `PackageReference` for `xunit.analyzers` to include it in the build process.
* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156R58): Added a `PackageVersion` entry for `xunit.analyzers` with version `1.22.0` and marked it as `PrivateAssets="all"` to prevent it from being exposed as a transitive dependency.