### PR TITLE
refactor: remove Domain and Audit entries from build and sign scripts

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -7,14 +7,11 @@ $dirs=[ordered]@{
     6="Cryptography";
     7="Hosting";
     8="Tools";
-    9="Domain";
-    10="Mvc";
-    11="Webserver";
-    12="Webmaster";
-    13="Detection";
-    14="Responsive";
-    15="EntityFramework";
-    17="Analytics";
+    9="Mvc";
+    10="Webserver";
+    11="Webmaster";
+    12="Detection";
+    13="Responsive";
 }
 
 for ($i=0; $i -lt $dirs.count; $i++) {

--- a/sign.ps1
+++ b/sign.ps1
@@ -16,15 +16,11 @@ $dirs=[ordered]@{
 #    6="Cryptography";
 #    7="Hosting";
 #    8="Tools";
-#    9="Domain";
-#    10="Audit";
-#    11="Mvc";
-#    12="Webserver";
-#    13="Webmaster";
-#    14="Detection";
-#    15="Responsive";
-#    16="EntityFramework";
-#    18="Analytics";
+#    9="Mvc";
+#    10="Webserver";
+#    11="Webmaster";
+#    12="Detection";
+#    13="Responsive";
 }
 
 $env:OneDriveConsumer + "\powershell-env.ps1" | out-null


### PR DESCRIPTION
This pull request updates the list of project directories in both the `build.ps1` and `sign.ps1` scripts. The changes primarily reorder and remove certain directories, ensuring that only relevant components are included for build and signing operations.

Directory list updates:

* In `build.ps1`, the `Domain`, `EntityFramework`, and `Analytics` directories are removed, and the remaining directories are reordered to prioritize `Mvc`, `Webserver`, `Webmaster`, `Detection`, and `Responsive` after `Tools`.
* In `sign.ps1`, the commented-out directory list is updated to match the new order, removing `Domain`, `Audit`, `EntityFramework`, and `Analytics`, and reordering the remaining entries for consistency.